### PR TITLE
feat(scripts): add `git-lfs` and `rustup` dependency checks

### DIFF
--- a/scripts/mlc-prepare.js
+++ b/scripts/mlc-prepare.js
@@ -4,6 +4,35 @@ const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
+// Check for required dependencies
+function checkDependency(command, name) {
+  try {
+    execSync(`which ${command}`, { stdio: 'ignore' });
+    console.log(`✅ ${name} found in PATH`);
+    return true;
+  } catch (error) {
+    console.error(
+      `❌ ${name} not found in PATH. Please install ${name} first.`
+    );
+    return false;
+  }
+}
+
+// Validate required dependencies
+const hasGitLFS = checkDependency('git-lfs', 'Git LFS');
+const hasRustup = checkDependency('rustup', 'Rustup');
+
+if (!hasGitLFS || !hasRustup) {
+  console.error('\n🔧 Please install the missing dependencies:');
+  if (!hasGitLFS) {
+    console.error('- Git LFS: https://git-lfs.com');
+  }
+  if (!hasRustup) {
+    console.error('- Rustup: https://rustup.rs');
+  }
+  process.exit(1);
+}
+
 const projectRoot = process.cwd();
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
## Description
This PR adds validation for required system dependencies (`git-lfs` and `rustup`) to the MLC model preparation script. This ensures users have all necessary tools installed before attempting to prepare models.

## Changes
- Added `checkDependency` helper function to validate command availability
- Added checks for `git-lfs` and `rustup` presence in PATH
- Added user-friendly error messages with installation URLs when dependencies are missing

## Why
- Git LFS is required for handling large model files
- Rustup is needed for MLC toolchain compilation
- Early validation prevents confusing errors later in the build process

## Testing
1. With all dependencies:
   ```bash
   # Should proceed normally
   yarn mlc-prepare
   ```

2. Without Git LFS:
   ```bash
   # Should show error with Git LFS installation instructions
   # Remove or rename git-lfs temporarily to test
   mv $(which git-lfs) git-lfs.bak
   yarn mlc-prepare
   ```

3. Without Rustup:
   ```bash
   # Should show error with Rustup installation instructions
   # Remove or rename rustup temporarily to test
   mv $(which rustup) rustup.bak
   yarn mlc-prepare
   ```