### PR TITLE
feat: add `downloaded` property to output

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -105,27 +105,31 @@ export default function Example() {
     async (modelSettings: AiModelSettings) => {
       if (modelSettings.model_id) {
         setModelId(modelSettings.model_id);
-
-        addAiBotMessage('Downloading model...');
-        await downloadModel(modelSettings.model_id, {
-          onStart: () => {
-            addAiBotMessage('Starting model download...');
-          },
-          onProgress: (progress) => {
-            setDownloadProgress(progress.percentage);
-          },
-          onComplete: () => {
-            setDownloadProgress(100);
-            addAiBotMessage('Model download complete!');
-          },
-          onError: (error) => {
-            setDownloadProgress(0);
-            addAiBotMessage(`Error downloading model: ${error.message}`);
-          },
-        });
-
+        if (modelSettings.downloaded) {
+          addAiBotMessage('Model already downloaded!');
+          setDownloadProgress(100);
+        } else {
+          setDownloadProgress(0);
+          addAiBotMessage('Downloading model...');
+          await downloadModel(modelSettings.model_id, {
+            onStart: () => {
+              addAiBotMessage('Starting model download...');
+            },
+            onProgress: (progress) => {
+              setDownloadProgress(progress.percentage);
+            },
+            onComplete: () => {
+              setDownloadProgress(100);
+              addAiBotMessage('Model download complete!');
+            },
+            onError: (error) => {
+              setDownloadProgress(0);
+              addAiBotMessage(`Error downloading model: ${error.message}`);
+            },
+          });
+        }
+        addAiBotMessage('Preparing model...');
         await prepareModel(modelSettings.model_id);
-
         addAiBotMessage('Model ready for conversation.');
       }
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ export default Ai;
 
 export interface AiModelSettings extends Record<string, unknown> {
   model_id?: string;
+  downloaded?: boolean;
 }
 
 export interface Model {


### PR DESCRIPTION
Before, we didn't have any indicator that the model was already downloaded. This PR adds a boolean `downloaded` property to the `getModels` result.