### PR TITLE
refactor: better LLM output parsing 

### DIFF
--- a/packages/apple-llm/ios/AppleLLM.mm
+++ b/packages/apple-llm/ios/AppleLLM.mm
@@ -114,8 +114,8 @@ using namespace JS::NativeAppleLLM;
     @"maxTokens": options.maxTokens().has_value() ? @(options.maxTokens().value()) : [NSNull null],
     @"topP": options.topP().has_value() ? @(options.topP().value()) : [NSNull null],
     @"topK": options.topK().has_value() ? @(options.topK().value()) : [NSNull null],
-    @"schema": options.schema(),
-    @"tools": options.tools()
+    @"schema": options.schema() ?: [NSNull null],
+    @"tools": options.tools() ?: [NSNull null]
   };
   
   auto callToolBlock = ^(NSString *toolName, id parameters, void (^completion)(id, NSError *)) {
@@ -136,7 +136,7 @@ using namespace JS::NativeAppleLLM;
     @"maxTokens": options.maxTokens().has_value() ? @(options.maxTokens().value()) : [NSNull null],
     @"topP": options.topP().has_value() ? @(options.topP().value()) : [NSNull null],
     @"topK": options.topK().has_value() ? @(options.topK().value()) : [NSNull null],
-    @"schema": options.schema()
+    @"schema": options.schema() ?: [NSNull null]
   };
   
   NSError *error;

--- a/packages/apple-llm/ios/AppleLLMImpl.swift
+++ b/packages/apple-llm/ios/AppleLLMImpl.swift
@@ -14,17 +14,13 @@ import FoundationModels
 #endif
 
 public typealias ToolInvoker = @Sendable (String, [String : Any], @escaping (Any?, Error?) -> Void) -> Void
+public typealias ResolveBlock = @escaping (Any?) -> Void
+public typealias RejectBlock = @escaping (String, String, Error?) -> Void
 
 @objc
 public class AppleLLMImpl: NSObject {
   
   private var streamTasks: [String: Task<Void, Never>] = [:]
-  
-  // MARK: - Constants
-  
-  private static let supportedStringFormats: Set<String> = [
-    "date-time", "time", "date", "duration", "email", "hostname", "ipv4", "ipv6", "uuid"
-  ]
   
   @objc
   public func isAvailable() -> Bool {
@@ -43,8 +39,8 @@ public class AppleLLMImpl: NSObject {
   public func generateText(
     _ messages: [[String: Any]],
     options: [String: Any],
-    resolve: @escaping (Any?) -> Void,
-    reject: @escaping (String, String, Error?) -> Void,
+    resolve: ResolveBlock,
+    reject: RejectBlock,
     toolInvoker: @escaping ToolInvoker
   ) {
 #if canImport(FoundationModels)
@@ -178,8 +174,8 @@ public class AppleLLMImpl: NSObject {
   @objc
   public func isModelAvailable(
     _ modelId: String,
-    resolve: @escaping (Any?) -> Void,
-    reject: @escaping (String, String, Error?) -> Void
+    resolve: ResolveBlock,
+    reject: RejectBlock
   ) {
 #if canImport(FoundationModels)
     if #available(iOS 26, *) {
@@ -345,12 +341,6 @@ public class AppleLLMImpl: NSObject {
   
   @available(iOS 26, *)
   struct AppleLLMSchemaParser {
-    
-    // MARK: - Constants
-    private static let supportedStringFormats: Set<String> = [
-      "date-time", "time", "date", "duration", "email", "hostname", "ipv4", "ipv6", "uuid"
-    ]
-    
     static func createGenerationSchema(from schemaDict: [String: Any]) throws -> GenerationSchema {
       let dynamicSchemas = try parseDynamicSchema(from: schemaDict)
       return try GenerationSchema(root: dynamicSchemas, dependencies: [])

--- a/packages/apple-llm/src/NativeAppleLLM.ts
+++ b/packages/apple-llm/src/NativeAppleLLM.ts
@@ -38,7 +38,7 @@ export interface Spec extends TurboModule {
   generateText(
     messages: AppleMessage[],
     options: AppleGenerationOptions
-  ): Promise<string>
+  ): Promise<string | UnsafeObject>
   generateStream(
     messages: AppleMessage[],
     options: AppleGenerationOptions

--- a/packages/apple-llm/src/ai-sdk.ts
+++ b/packages/apple-llm/src/ai-sdk.ts
@@ -36,7 +36,7 @@ export class AppleLLMChatLanguageModel implements LanguageModelV1 {
   async doGenerate(options: LanguageModelV1CallOptions) {
     const messages = this.convertMessages(options.prompt)
 
-    const text = await NativeAppleLLM.generateText(messages, {
+    const response = await NativeAppleLLM.generateText(messages, {
       maxTokens: options.maxTokens,
       temperature: options.temperature,
       topP: options.topP,
@@ -44,7 +44,7 @@ export class AppleLLMChatLanguageModel implements LanguageModelV1 {
     })
 
     return {
-      text,
+      text: typeof response === 'string' ? response : JSON.stringify(response),
       finishReason: 'stop' as const,
       // Apple LLM doesn't provide token counts.
       // We will have to handle this ourselves in the future to avoid errors.

--- a/packages/apple-llm/src/index.ts
+++ b/packages/apple-llm/src/index.ts
@@ -71,11 +71,6 @@ async function generateText(
     generationOptions
   )
 
-  if (schema) {
-    const parsed = schema.parse(JSON.parse(response))
-    return parsed
-  }
-
   return response
 }
 


### PR DESCRIPTION
Fixes #64 
Fixes #62 
Removed dead code 

--

In #59 I introduce a better way to get output out of GeneratedContent that doesn't involve using reflection and private APIs, so moving this to it too. As a result, we pass objects back to React Native, without need to JSON serialize it, and then, parse with Zod.