### PR TITLE
chore: use prettierrc instead of inline eslint config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "quoteProps": "consistent",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "semi": false
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,17 +28,7 @@ export default defineConfig([
   // Configure Prettier
   {
     rules: {
-      'prettier/prettier': [
-        'error',
-        {
-          quoteProps: 'consistent',
-          singleQuote: true,
-          tabWidth: 2,
-          trailingComma: 'es5',
-          useTabs: false,
-          semi: false,
-        },
-      ],
+      'prettier/prettier': 'error',
     },
   },
 ])

--- a/packages/apple-llm/src/NativeAppleLLM.ts
+++ b/packages/apple-llm/src/NativeAppleLLM.ts
@@ -62,7 +62,6 @@ export interface Spec extends TurboModule {
   onStreamUpdate: EventEmitter<StreamUpdateEvent>
   onStreamComplete: EventEmitter<StreamCompleteEvent>
   onStreamError: EventEmitter<StreamErrorEvent>
-
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('NativeAppleLLM')


### PR DESCRIPTION
### Summary

- [x] - move prettier config to `.prettierrc` (single source of truth for all tools)
- [x] - reformat