### PR TITLE
refactor: generateText/Stream to be more universal

### DIFF
--- a/packages/mlc/ios/MLCEngine.mm
+++ b/packages/mlc/ios/MLCEngine.mm
@@ -470,7 +470,7 @@ using namespace facebook;
         return;
       }
       
-      resolve([NSString stringWithFormat:@"Model downloaded: %@", modelId]);
+      resolve(nil);
     } @catch (NSException* exception) {
       reject(@"MLCEngine", exception.reason, nil);
     }
@@ -482,33 +482,25 @@ using namespace facebook;
              reject:(RCTPromiseRejectBlock)reject {
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     @try {
-      // Build path to model directory
       NSURL* modelDirURL = [self.bundleURL URLByAppendingPathComponent:modelId];
       NSString* modelDirPath = [modelDirURL path];
       
-      NSLog(@"Cleaning downloaded model at path: %@", modelDirPath);
-      
-      // Check if directory exists
       BOOL isDirectory;
       if ([[NSFileManager defaultManager] fileExistsAtPath:modelDirPath isDirectory:&isDirectory]) {
         if (isDirectory) {
-          // Remove the entire model directory
           NSError* removeError;
           BOOL removed = [[NSFileManager defaultManager] removeItemAtPath:modelDirPath error:&removeError];
           
           if (removed) {
-            NSLog(@"Successfully cleaned model directory: %@", modelId);
-            resolve([NSString stringWithFormat:@"Model cleaned: %@", modelId]);
+            resolve(nil);
           } else {
-            NSLog(@"Failed to clean model directory: %@", removeError);
             reject(@"MLCEngine", [NSString stringWithFormat:@"Failed to clean model: %@", removeError.localizedDescription], removeError);
           }
         } else {
           reject(@"MLCEngine", @"Path exists but is not a directory", nil);
         }
       } else {
-        NSLog(@"Model directory does not exist, nothing to clean");
-        resolve(@"Model directory does not exist");
+        resolve(nil);
       }
     } @catch (NSException* exception) {
       reject(@"MLCEngine", exception.reason, nil);
@@ -519,7 +511,13 @@ using namespace facebook;
 - (void)unloadModel:(RCTPromiseResolveBlock)resolve
              reject:(RCTPromiseRejectBlock)reject {
   [self.engine unload];
-  resolve(@"Model unloaded successfully");
+  resolve(nil);
 }
+
+- (void)cancelStream:(nonnull NSString *)streamId resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject { 
+  [self.engine cancelRequest:streamId];
+  resolve(nil);
+}
+
 
 @end

--- a/packages/mlc/ios/engine/EngineState.h
+++ b/packages/mlc/ios/engine/EngineState.h
@@ -17,6 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
                                 request:(NSDictionary *)request
                              completion:(void (^)(NSDictionary* response))completion;
 - (void)streamCallbackWithResult:(NSString *)result;
+- (void)cancelRequest:(NSString *)requestId
+    withJSONFFIEngine:(JSONFFIEngine *)jsonFFIEngine;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/mlc/ios/engine/EngineState.mm
+++ b/packages/mlc/ios/engine/EngineState.mm
@@ -65,4 +65,9 @@
   }
 }
 
+- (void)cancelRequest:(NSString *)requestId withJSONFFIEngine:(JSONFFIEngine *)jsonFFIEngine {
+  [self.requestStateMap removeObjectForKey:requestId];
+  [jsonFFIEngine abort:requestId];
+}
+
 @end

--- a/packages/mlc/ios/engine/LLMEngine.h
+++ b/packages/mlc/ios/engine/LLMEngine.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unload;
 
 - (NSString*)chatCompletionWithMessages:(NSArray *)messages options:(NSDictionary *)options completion:(void (^)(NSDictionary* response))completion;
+- (void)cancelRequest:(NSString *)requestId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/mlc/ios/engine/LLMEngine.mm
+++ b/packages/mlc/ios/engine/LLMEngine.mm
@@ -68,4 +68,8 @@
   return [self.state chatCompletionWithJSONFFIEngine:self.jsonFFIEngine request:options completion:completion];
 }
 
+- (void)cancelRequest:(NSString *)requestId {
+  [self.state cancelRequest:requestId withJSONFFIEngine:self.jsonFFIEngine];
+}
+
 @end

--- a/packages/mlc/src/NativeMLCEngine.ts
+++ b/packages/mlc/src/NativeMLCEngine.ts
@@ -11,7 +11,7 @@ export interface Message {
   content: string
 }
 
-export interface CompletionUsageExtra extends Record<string, number> {
+export interface CompletionUsageExtra {
   ttft_s: number
   prefill_tokens_per_s: number
   prompt_tokens: number
@@ -99,13 +99,13 @@ export interface Spec extends TurboModule {
   ): Promise<GeneratedMessage>
 
   streamText(messages: Message[], options?: GenerationOptions): Promise<string>
-  cancelStream(streamId: string): Promise<string>
+  cancelStream(streamId: string): Promise<void>
 
-  downloadModel(modelId: string): Promise<string>
-  removeModel(modelId: string): Promise<string>
+  downloadModel(modelId: string): Promise<void>
+  removeModel(modelId: string): Promise<void>
 
-  prepareModel(modelId: string): Promise<string>
-  unloadModel(): Promise<string>
+  prepareModel(modelId: string): Promise<void>
+  unloadModel(): Promise<void>
 
   onChatUpdate: EventEmitter<ChatUpdateEvent>
   onChatComplete: EventEmitter<ChatCompleteEvent>

--- a/packages/mlc/src/ai-sdk.ts
+++ b/packages/mlc/src/ai-sdk.ts
@@ -164,7 +164,9 @@ class MlcChatLanguageModel implements LanguageModelV2 {
       },
       providerMetadata: {
         mlc: {
-          extraUsage: response.usage.extra,
+          extraUsage: {
+            ...response.usage.extra,
+          },
         },
       },
       warnings: [],
@@ -242,7 +244,9 @@ class MlcChatLanguageModel implements LanguageModelV2 {
               },
               providerMetadata: {
                 mlc: {
-                  extraUsage: data.usage.extra,
+                  extraUsage: {
+                    ...data.usage.extra,
+                  },
                 },
               },
             })


### PR DESCRIPTION
Always use stream (non-stream is not supported)
Update native resolution code to be more predictable
Expose more data from MLC LLM, and token usage
Add method to cancel stream and cancel it automatically

Overall, this should enable tool calling to work effectively, as soon as we get the working model. 