### PR TITLE
fix: properly initialize polyfill to evade RangeError due to @ungap/structured-clone

### DIFF
--- a/apps/example-apple/polyfills.ts
+++ b/apps/example-apple/polyfills.ts
@@ -2,4 +2,6 @@ import '@azure/core-asynciterator-polyfill'
 
 import structuredClone from '@ungap/structured-clone'
 
-globalThis.structuredClone = structuredClone
+if (!('structuredClone' in globalThis)) {
+  globalThis.structuredClone = structuredClone
+}


### PR DESCRIPTION
Currently, using the "Generate text" feature results in a `RangeError: maximum call stack size exceeded` error. This is caused by initialization logic of the `@ungap/structured-clone` polyfill and the issue has been encountered [here](https://github.com/ungap/structured-clone/issues/3#issuecomment-1005497915).

The fix is to set the polyfill only if `structuredClone` is not defined yet:

```typescript
import structuredClone from '@ungap/structured-clone'

if (!('structuredClone' in globalThis)) {
  globalThis.structuredClone = structuredClone
}
```