### PR TITLE
fix(types): mergeBuffersToFloat32Array to accept library's buffer type

### DIFF
--- a/apps/example-apple/src/utils/audioUtils.ts
+++ b/apps/example-apple/src/utils/audioUtils.ts
@@ -1,4 +1,5 @@
 import { addWAVHeader, AudioFormatType } from '@react-native-ai/apple'
+import type { AudioBuffer } from 'react-native-audio-api'
 
 /**
  * Merges multiple AudioBuffer objects into a single continuous Float32Array


### PR DESCRIPTION
This PR fixes a `typecheck` error due to the usage of web API `AudioBuffer` type instead of the one from `react-native-audio-api`.