### PR TITLE
fix(mlc): ignore non-text chat deltas before streaming

### DIFF
--- a/packages/mlc/src/ai-sdk.ts
+++ b/packages/mlc/src/ai-sdk.ts
@@ -220,10 +220,7 @@ class MlcChatLanguageModel implements LanguageModelV2 {
           })
 
           const updateListener = NativeMLCEngine.onChatUpdate((data) => {
-            if (data.delta) {
-              if (typeof data.delta?.content !== 'string') {
-                return
-              }
+            if (data.delta?.content) {
               controller.enqueue({
                 type: 'text-delta',
                 delta: data.delta.content,


### PR DESCRIPTION
1. Issue: In the iOS MLC demo, after finishing “Stream Text” the status panel throws TypeError: Cannot read property
     'length' of undefined.
2. Root cause: The native bridge’s last onChatUpdate emits `{"delta": {"role": "assistant"}}`. The JS layer forwards
   `delta.content` to the Vercel AI SDK without type checks, so the SDK receives undefined and crashes when it reads length.
3. Fix: Update onChatUpdate in packages/mlc/src/ai-sdk.ts to enqueue a text-delta only when delta.content is a string;
   ignore any other shape.

<img width="1170" height="2532" alt="9d6dba307ead68d448a06a39891e716c" src="https://github.com/user-attachments/assets/4ef20e66-be7b-4edd-87df-e0c37303d9e6" />

   
<img width="1119" height="198" alt="mlc_log" src="https://github.com/user-attachments/assets/c0fbedfb-1f10-4e38-83a4-486410be1c40" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a type guard in `packages/mlc/src/ai-sdk.ts` to only enqueue `text-delta` when `delta.content` is a string, ignoring other update shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 049d2b2420234d6ce21e441543ae559781c6574e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->