### PR TITLE
fix: freeze on Android due to mlc-llm problems handling `_1` models

### DIFF
--- a/packages/mlc/mlc-package-config-android.json
+++ b/packages/mlc/mlc-package-config-android.json
@@ -2,7 +2,7 @@
   "device": "android",
   "model_list": [
     {
-      "model": "HF://mlc-ai/Llama-3.2-1B-Instruct-q4f16_1-MLC",
+      "model": "HF://mlc-ai/Llama-3.2-1B-Instruct-q4f16_0-MLC",
       "model_id": "Llama-3.2-1B-Instruct",
       "estimated_vram_bytes": 1200000000,
       "bundle_weight": false,
@@ -12,7 +12,7 @@
       }
     },
     {
-      "model": "HF://mlc-ai/Llama-3.2-3B-Instruct-q4f16_1-MLC",
+      "model": "HF://mlc-ai/Llama-3.2-3B-Instruct-q4f16_0-MLC",
       "model_id": "Llama-3.2-3B-Instruct",
       "estimated_vram_bytes": 2000000000,
       "bundle_weight": false,
@@ -22,7 +22,7 @@
       }
     },
     {
-      "model": "HF://mlc-ai/Phi-3.5-mini-instruct-q4f16_1-MLC",
+      "model": "HF://mlc-ai/Phi-3.5-mini-instruct-q4f16_0-MLC",
       "model_id": "Phi-3.5-mini-instruct",
       "estimated_vram_bytes": 2300000000,
       "bundle_weight": false,
@@ -32,8 +32,8 @@
       }
     },
     {
-      "model": "HF://mlc-ai/Qwen2.5-0.5B-Instruct-q4f16_1-MLC",
-      "model_id": "Qwen2.5-0.5B-Instruct",
+      "model": "HF://mlc-ai/Qwen2-1.5B-Instruct-q4f16_0-MLC",
+      "model_id": "Qwen2-1.5B-Instruct",
       "estimated_vram_bytes": 600000000,
       "bundle_weight": false,
       "overrides": {


### PR DESCRIPTION
This PR is a workaround for the issue with initial ~10-20s freeze on Android (only) during the first inference of a model's instance. The issue is tracked https://github.com/mlc-ai/mlc-llm/issues/3363 and there is no definite fix, but the issue has been identified to be the prefill phase taking long to allocate data on the GPU on Android, at least on Adreno hardware, for `_1` models. The `_0` model format, on the other hand, works fine; this PR changes 3 models to be `_0` and the same for Qwen, however, since there is no prebuilt quantized model of Qwen2.5 that is `_0`, Qwen 2 has been used instead.

CC @grabbou @MasterJH5574