### PR TITLE
fix: example app to show reasoning of Llama only if non-empty

### DIFF
--- a/apps/expo-example/src/screens/LlamaRNScreen.tsx
+++ b/apps/expo-example/src/screens/LlamaRNScreen.tsx
@@ -233,7 +233,14 @@ export default function LlamaRNScreen() {
         setMessages([
           ...exampleMessages,
           { role: 'assistant', content: accumulatedContent },
-          { role: 'system', content: `Reasoning: ${accumulatedReasoning}` },
+          ...(accumulatedReasoning.trim().length
+            ? [
+                {
+                  role: 'system',
+                  content: `Reasoning: ${accumulatedReasoning}`,
+                } as const,
+              ]
+            : []),
         ])
       }
     } catch (error) {


### PR DESCRIPTION
This PR fixes the example app to only show reasoning block if it is non-empty.