### PR TITLE
fix(llama): emit first token in streaming response

### DIFF
--- a/apps/expo-example/src/screens/LlamaRNScreen.tsx
+++ b/apps/expo-example/src/screens/LlamaRNScreen.tsx
@@ -39,14 +39,15 @@ const MODELS: ModelOption[] = [
     size: '1.78GB',
   },
   {
+    name: 'FunctionGemma 270M IT (Q4_K_M)',
+    modelId:
+      'unsloth/functiongemma-270m-it-GGUF/functiongemma-270m-it-Q4_K_M.gguf',
+    size: '240MB',
+  },
+  {
     name: 'Qwen 3 4B (Q3_K_M)',
     modelId: 'Qwen/Qwen2.5-3B-Instruct-GGUF/qwen2.5-3b-instruct-q3_k_m.gguf',
     size: '1.93GB',
-  },
-  {
-    name: 'Gemma 2 2B IT (Q3_K_M)',
-    modelId: 'lmstudio-community/gemma-2-2b-it-GGUF/gemma-2-2b-it-Q3_K_M.gguf',
-    size: '2.31GB',
   },
 ]
 

--- a/packages/llama/src/ai-sdk.ts
+++ b/packages/llama/src/ai-sdk.ts
@@ -378,6 +378,11 @@ export class LlamaLanguageModel implements LanguageModelV2 {
                           type: 'text-start',
                           id: textId,
                         })
+                        controller.enqueue({
+                          type: 'text-delta',
+                          id: textId,
+                          delta: token,
+                        })
                         break
 
                       case 'text':


### PR DESCRIPTION
The first token was being dropped when starting a text block because the code only enqueued 'text-start' and then broke without enqueuing the actual token as 'text-delta'.