### PR TITLE
docs: fix documentation for tool calling with apple

### DIFF
--- a/website/src/docs/apple/generating.md
+++ b/website/src/docs/apple/generating.md
@@ -87,7 +87,7 @@ import { z } from 'zod';
 
 const getWeather = tool({
   description: 'Get current weather information',
-  parameters: z.object({
+  inputSchema: z.object({
     city: z.string()
   }),
   execute: async ({ city }) => {


### PR DESCRIPTION
After struggling for a while to get tool calling working on Apple I noticed demo project uses inputSchema and not parameters.
This might be helpful for other devs looking at documentation. 