### PR TITLE
docs: add Llama Engine to provider documentation

### DIFF
--- a/website/src/docs/index.md
+++ b/website/src/docs/index.md
@@ -22,6 +22,16 @@ Native integration with Apple's on-device AI capabilities through `@react-native
 
 Production-ready with instant availability on supported iOS devices.
 
+### Llama Engine
+
+Run any GGUF model from HuggingFace locally using `llama.rn` through `@react-native-ai/llama`:
+
+- **Text Generation** - High-performance GGUF inference with full streaming support
+- **Model Management** - Automatic downloading and caching from HuggingFace
+- **Customizable** - Support for context size, threads, and GGUF-specific parameters
+
+Cross-platform parity with optimized performance on both iOS and Android.
+
 ### MLC Engine (Work in Progress)
 
 Run any open-source LLM locally using MLC's optimized runtime through `@react-native-ai/mlc`:


### PR DESCRIPTION
**Summary**
This PR adds the Llama Engine to the list of available providers in the Introduction page of the documentation.

**Changes**
- Added a new (missing) section for Llama Engine between Apple Intelligence and MLC Engine in the Introduction page located at `website/src/docs/index.md`.