### PR TITLE
feat: unify apple and llama models on API (prepare) and storage methods

### DIFF
--- a/packages/llama/src/index.ts
+++ b/packages/llama/src/index.ts
@@ -1,16 +1,12 @@
 export type {
-  DownloadProgress,
   LlamaEmbeddingOptions,
   LlamaModelOptions,
-  LlamaProviderOptions,
   LlamaSpeechOptions,
-  ModelInfo,
 } from './ai-sdk'
 export {
   createLlamaProvider,
   llama,
   LlamaEmbeddingModel,
-  LlamaEngine,
   LlamaLanguageModel,
   LlamaSpeechModel,
 } from './ai-sdk'
@@ -23,3 +19,6 @@ export type {
   RerankResult,
   TokenData,
 } from 'llama.rn'
+// Storage APIs for model management
+export type { DownloadProgress } from './storage'
+export { downloadModel, getModelPath, isModelDownloaded } from './storage'

--- a/packages/llama/src/storage.ts
+++ b/packages/llama/src/storage.ts
@@ -1,6 +1,6 @@
 import RNBlobUtil from 'react-native-blob-util'
 
-let storagePath = `${RNBlobUtil.fs.dirs.DocumentDir}/llama-models`
+const DEFAULT_STORAGE_PATH = `${RNBlobUtil.fs.dirs.DocumentDir}/llama-models`
 
 export interface DownloadProgress {
   percentage: number
@@ -11,14 +11,6 @@ export interface ModelInfo {
   path: string
   filename: string
   sizeBytes?: number
-}
-
-export function setStoragePath(path: string): void {
-  storagePath = path
-}
-
-export function getStoragePath(): string {
-  return storagePath
 }
 
 export function parseModelId(modelId: string): {
@@ -38,7 +30,7 @@ export function parseModelId(modelId: string): {
 
 export function getModelPath(modelId: string): string {
   const { filename } = parseModelId(modelId)
-  return `${storagePath}/${filename}`
+  return `${DEFAULT_STORAGE_PATH}/${filename}`
 }
 
 export async function isModelDownloaded(modelId: string): Promise<boolean> {
@@ -48,17 +40,17 @@ export async function isModelDownloaded(modelId: string): Promise<boolean> {
 
 export async function getDownloadedModels(): Promise<ModelInfo[]> {
   try {
-    const exists = await RNBlobUtil.fs.exists(storagePath)
+    const exists = await RNBlobUtil.fs.exists(DEFAULT_STORAGE_PATH)
     if (!exists) {
       return []
     }
 
-    const files = await RNBlobUtil.fs.ls(storagePath)
+    const files = await RNBlobUtil.fs.ls(DEFAULT_STORAGE_PATH)
     const models: ModelInfo[] = []
 
     for (const filename of files) {
       if (filename.endsWith('.gguf')) {
-        const path = `${storagePath}/${filename}`
+        const path = `${DEFAULT_STORAGE_PATH}/${filename}`
         const stat = await RNBlobUtil.fs.stat(path)
 
         models.push({
@@ -83,11 +75,11 @@ export async function downloadModel(
 ): Promise<string> {
   const { repo, filename } = parseModelId(modelId)
   const url = `https://huggingface.co/${repo}/resolve/main/${filename}?download=true`
-  const destPath = `${storagePath}/${filename}`
+  const destPath = `${DEFAULT_STORAGE_PATH}/${filename}`
 
-  const dirExists = await RNBlobUtil.fs.exists(storagePath)
+  const dirExists = await RNBlobUtil.fs.exists(DEFAULT_STORAGE_PATH)
   if (!dirExists) {
-    await RNBlobUtil.fs.mkdir(storagePath)
+    await RNBlobUtil.fs.mkdir(DEFAULT_STORAGE_PATH)
   }
 
   const fileExists = await RNBlobUtil.fs.exists(destPath)

--- a/website/src/docs/apple/embeddings.md
+++ b/website/src/docs/apple/embeddings.md
@@ -52,17 +52,14 @@ console.log(embeddings)
 
 ## Language Support
 
-The embeddings model supports multiple languages. You can specify the language using [ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) or full names:
+The embeddings model supports multiple languages. You can specify the language using [ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) or full names when creating the model:
 
 ```tsx
+const model = apple.textEmbeddingModel({ language: 'fr' })
+
 await embed({
-  model: apple.textEmbeddingModel(), 
+  model,
   value: 'Bonjour',
-  providerOptions: {
-    apple: {
-      language: 'fr',
-    }
-  }
 })
 ```
 
@@ -71,17 +68,24 @@ For list of all supported languages, [check Apple documentation](https://develop
 > [!NOTE]
 > By default, the embeddings model will use device language.
 
-## Asset Management
+## Preparing the Model
 
-Apple's NLContextualEmbedding requires downloading language-specific assets to the device. The provider automatically requests assets when needed, but you can also prepare them manually:
+Apple's NLContextualEmbedding requires downloading language-specific assets to the device. While the provider automatically prepares assets when needed, you can call `prepare()` ahead of time for better performance:
 
 ```tsx
-import { NativeAppleEmbeddings } from '@react-native-ai/apple'
+const model = apple.textEmbeddingModel({ language: 'en' })
 
-await NativeAppleEmbeddings.prepare('en')
+// Call prepare() ahead of time to optimize first inference latency
+await model.prepare()
+
+// Now embeddings will be faster on first use
+const { embedding } = await embed({ model, value: 'Hello world' })
 ```
 
-When you call `prepare()` for a language, the system first checks if the required assets are already present on the device. If they are, the method resolves immediately without any network activity, making subsequent embedding operations instant.
+> [!TIP]
+> Calling `prepare()` ahead of time is recommended to avoid delays on first use. If not called, the model will auto-prepare when first used, but a warning will be logged.
+
+When you call `prepare()`, the system first checks if the required assets are already present on the device. If they are, the method resolves immediately without any network activity.
 
 > [!NOTE]
 > All language models and assets are stored in Apple's system-wide assets catalog, separate from your app bundle. This means zero impact on your app's size. Assets may already be available if the user has previously used other apps, or if system features have requested them.

--- a/website/src/docs/apple/transcription.md
+++ b/website/src/docs/apple/transcription.md
@@ -37,34 +37,38 @@ The `audio` parameter accepts either an `ArrayBuffer` or a base64-encoded string
 
 ## Language Support
 
-The transcription model supports multiple languages with automatic language detection. You can configure a custom one with this API:
+The transcription model supports multiple languages with automatic language detection. You can configure a custom language when creating the model:
 
 ```tsx
+const model = apple.transcriptionModel({ language: 'fr' })
+
 await experimental_transcribe({
-  model: apple.transcriptionModel(),
+  model,
   audio: audioArrayBuffer,
-  providerOptions: {
-    apple: {
-      language: 'fr',
-    },
-  },
 })
 ```
 
 > [!NOTE]
 > By default, the transcription model will use device language.
 
-## Asset Management
+## Preparing the Model
 
-Apple's SpeechAnalyzer requires downloading language-specific assets to the device. The provider automatically requests assets when needed, but you can also prepare them manually:
+Apple's SpeechAnalyzer requires downloading language-specific assets to the device. While the provider automatically prepares assets when needed, you can call `prepare()` ahead of time for better performance:
 
 ```tsx
-import { NativeAppletranscription } from '@react-native-ai/apple'
+const model = apple.transcriptionModel({ language: 'en' })
 
-await NativeAppletranscription.prepare('en')
+// Call prepare() ahead of time to optimize first inference latency
+await model.prepare()
+
+// Now transcription will be faster on first use
+const response = await experimental_transcribe({ model, audio })
 ```
 
-When you call `prepare()` for a language, the system first checks if the required assets are already present on the device. If they are, the method resolves immediately without any network activity, making subsequent embedding operations instant.
+> [!TIP]
+> Calling `prepare()` ahead of time is recommended to avoid delays on first use. If not called, the model will auto-prepare when first used, but a warning will be logged.
+
+When you call `prepare()`, the system first checks if the required assets are already present on the device. If they are, the method resolves immediately without any network activity.
 
 > [!NOTE]
 > All language models and assets are stored in Apple's system-wide assets catalog, separate from your app bundle. This means zero impact on your app's size. Assets may already be available if the user has previously used other apps, or if system features have requested them.

--- a/website/src/docs/llama/embeddings.md
+++ b/website/src/docs/llama/embeddings.md
@@ -10,15 +10,15 @@ Generate text embeddings for RAG (Retrieval-Augmented Generation), semantic sear
 ## Basic Usage
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { embed } from 'ai'
 
-// Create embedding model
-const model = llama.textEmbeddingModel(
-  'owner/repo/embedding-model.gguf'
-)
+// Download embedding model - returns the file path
+const modelPath = await downloadModel('owner/repo/embedding-model.gguf')
 
-await model.download()
+// Create embedding model with the path
+const model = llama.textEmbeddingModel(modelPath)
+
 await model.prepare()
 
 // Generate embedding for a single text
@@ -35,13 +35,12 @@ console.log(embedding) // [0.123, -0.456, ...]
 Generate embeddings for multiple texts:
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { embedMany } from 'ai'
 
-const model = llama.textEmbeddingModel(
-  'owner/repo/embedding-model.gguf'
-)
-await model.download()
+const modelPath = await downloadModel('owner/repo/embedding-model.gguf')
+
+const model = llama.textEmbeddingModel(modelPath)
 await model.prepare()
 
 const { embeddings } = await embedMany({
@@ -62,17 +61,14 @@ console.log(embeddings[0].length) // Embedding dimension (e.g., 384, 768)
 Configure the embedding model with specific options:
 
 ```typescript
-const model = llama.textEmbeddingModel(
-  'owner/repo/embedding-model.gguf',
-  {
-    normalize: -1, // Normalization mode (default: -1)
-    contextParams: {
-      n_ctx: 2048, // Context size (default: 2048)
-      n_gpu_layers: 99, // GPU layers (default: 99)
-      n_parallel: 8, // Parallel embeddings (default: 8)
-    },
-  }
-)
+const model = llama.textEmbeddingModel(modelPath, {
+  normalize: -1, // Normalization mode (default: -1)
+  contextParams: {
+    n_ctx: 2048, // Context size (default: 2048)
+    n_gpu_layers: 99, // GPU layers (default: 99)
+    n_parallel: 8, // Parallel embeddings (default: 8)
+  },
+})
 ```
 
 ### Options
@@ -90,5 +86,4 @@ Release resources when done:
 
 ```typescript
 await model.unload() // Release from memory
-await model.remove() // Delete from disk (optional)
 ```

--- a/website/src/docs/llama/generating.md
+++ b/website/src/docs/llama/generating.md
@@ -10,14 +10,13 @@ You can generate responses using Llama models with the Vercel AI SDK's `generate
 ## Text Generation
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { generateText } from 'ai'
 
-// Create and prepare model
-const model = llama.languageModel(
-  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
-)
-await model.download()
+// Download model - returns the file path
+const modelPath = await downloadModel('ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf')
+
+const model = llama.languageModel(modelPath)
 await model.prepare()
 
 const result = await generateText({
@@ -33,14 +32,13 @@ console.log(result.text)
 Stream responses for real-time output:
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { streamText } from 'ai'
 
-// Create and prepare model
-const model = llama.languageModel(
-  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
-)
-await model.download()
+// Download model - returns the file path
+const modelPath = await downloadModel('ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf')
+
+const model = llama.languageModel(modelPath)
 await model.prepare()
 
 const { textStream } = streamText({
@@ -58,17 +56,15 @@ for await (const delta of textStream) {
 The Llama provider supports multimodal models that can process images and audio. To enable multimodal capabilities, provide a `projectorPath` when creating the model:
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { generateText } from 'ai'
 
-const model = llama.languageModel(
-  'owner/repo/vision-model.gguf',
-  {
-    projectorPath: '/path/to/mmproj-model.gguf',
-  }
-)
+const modelPath = await downloadModel('owner/repo/vision-model.gguf')
 
-await model.download()
+const model = llama.languageModel(modelPath, {
+  projectorPath: '/path/to/mmproj-model.gguf',
+})
+
 await model.prepare()
 
 // Use with images
@@ -107,13 +103,12 @@ const result = await generateText({
 Models that support reasoning (like DeepSeek-R1) automatically handle `<think>` tags. The reasoning content is separated from the main response:
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { generateText } from 'ai'
 
-const model = llama.languageModel(
-  'owner/repo/deepseek-r1.gguf'
-)
-await model.download()
+const modelPath = await downloadModel('owner/repo/deepseek-r1.gguf')
+
+const model = llama.languageModel(modelPath)
 await model.prepare()
 
 const result = await generateText({
@@ -135,14 +130,13 @@ When streaming, reasoning tokens are emitted separately via `reasoning-start`, `
 Generate structured JSON responses:
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { generateObject } from 'ai'
 import { z } from 'zod'
 
-const model = llama.languageModel(
-  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
-)
-await model.download()
+const modelPath = await downloadModel('ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf')
+
+const model = llama.languageModel(modelPath)
 await model.prepare()
 
 const { object } = await generateObject({
@@ -177,13 +171,12 @@ Configure model behavior with generation options:
 Example with all options:
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { generateText } from 'ai'
 
-const model = llama.languageModel(
-  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
-)
-await model.download()
+const modelPath = await downloadModel('ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf')
+
+const model = llama.languageModel(modelPath)
 await model.prepare()
 
 const result = await generateText({
@@ -205,29 +198,23 @@ const result = await generateText({
 When creating a model instance, you can configure llama.rn specific options via `contextParams`:
 
 ```typescript
-const model = llama.languageModel(
-  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf',
-  {
-    contextParams: {
-      n_ctx: 4096, // Context size (default: 2048, or 4096 for multimodal)
-      n_gpu_layers: 99, // Number of GPU layers (default: 99)
-    },
-  }
-)
+const model = llama.languageModel(modelPath, {
+  contextParams: {
+    n_ctx: 4096, // Context size (default: 2048, or 4096 for multimodal)
+    n_gpu_layers: 99, // Number of GPU layers (default: 99)
+  },
+})
 ```
 
 For multimodal models:
 
 ```typescript
-const model = llama.languageModel(
-  'owner/repo/vision-model.gguf',
-  {
-    projectorPath: '/path/to/mmproj.gguf', // Required for multimodal
-    projectorUseGpu: true, // Use GPU for multimodal (default: true)
-    contextParams: {
-      n_ctx: 4096,
-      n_gpu_layers: 99,
-    },
-  }
-)
+const model = llama.languageModel(modelPath, {
+  projectorPath: '/path/to/mmproj.gguf', // Required for multimodal
+  projectorUseGpu: true, // Use GPU for multimodal (default: true)
+  contextParams: {
+    n_ctx: 4096,
+    n_gpu_layers: 99,
+  },
+})
 ```

--- a/website/src/docs/llama/getting-started.md
+++ b/website/src/docs/llama/getting-started.md
@@ -63,16 +63,14 @@ The Llama provider supports multiple model types:
 Import the Llama provider and use it with the AI SDK:
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
+import { llama, downloadModel } from '@react-native-ai/llama'
 import { streamText } from 'ai'
 
-// Create model instance (Model ID format: "owner/repo/filename.gguf")
-const model = llama.languageModel(
-  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
-)
+// Download model from HuggingFace - returns the file path
+const modelPath = await downloadModel('ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf')
 
-// Download from HuggingFace
-await model.download()
+// Create model instance with the path
+const model = llama.languageModel(modelPath)
 
 // Initialize model (loads into memory)
 await model.prepare()

--- a/website/src/docs/llama/model-management.md
+++ b/website/src/docs/llama/model-management.md
@@ -20,53 +20,25 @@ Here are some popular models that work well on mobile devices:
 
 ## Model Lifecycle
 
-### Discovering Downloaded Models
+### Downloading Models
 
-Get the list of models that have been downloaded to the device:
+Models are downloaded from HuggingFace using the storage API. The `downloadModel` function returns the path to the downloaded file:
 
 ```typescript
-import { LlamaEngine } from '@react-native-ai/llama'
+import { downloadModel } from '@react-native-ai/llama'
 
-const models = await LlamaEngine.getModels()
+const modelPath = await downloadModel('ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf')
 
-console.log('Downloaded models:', models)
-// Output: [{ model_id: 'SmolLM3-Q4_K_M.gguf', path: '...', filename: '...', sizeBytes: 1800000000 }, ...]
+console.log('Downloaded to:', modelPath)
 ```
 
-### Creating Model Instances
-
-Create model instances using the provider methods:
+You can track download progress:
 
 ```typescript
-import { llama } from '@react-native-ai/llama'
-
-// Language model for text generation
-const languageModel = llama.languageModel(
-  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
-)
-
-// Embedding model for text embeddings
-const embeddingModel = llama.textEmbeddingModel(
-  'owner/repo/embedding-model.gguf'
-)
-
-// Speech model for text-to-speech (requires vocoder)
-const speechModel = llama.speechModel(
-  'owner/repo/tts-model.gguf',
-  { vocoderPath: '/path/to/vocoder.gguf' }
-)
-```
-
-With configuration options:
-
-```typescript
-const model = llama.languageModel(
+const modelPath = await downloadModel(
   'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf',
-  {
-    contextParams: {
-      n_ctx: 4096, // Context window size (default: 2048)
-      n_gpu_layers: 99, // GPU layers for acceleration (default: 99)
-    },
+  (progress) => {
+    console.log(`Download: ${progress.percentage}%`)
   }
 )
 ```
@@ -76,41 +48,59 @@ const model = llama.languageModel(
 Check if a model is already downloaded:
 
 ```typescript
-// Using instance method
-const isReady = await model.isDownloaded()
+import { isModelDownloaded, getModelPath } from '@react-native-ai/llama'
 
-// Or using LlamaEngine
-import { LlamaEngine } from '@react-native-ai/llama'
-const isDownloaded = await LlamaEngine.isDownloaded(
-  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
-)
+const modelId = 'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
+
+if (await isModelDownloaded(modelId)) {
+  // Model already downloaded, get its path
+  const modelPath = getModelPath(modelId)
+}
 ```
 
-### Downloading Models
+### Creating Model Instances
 
-Models are downloaded from HuggingFace automatically:
+Create model instances using the provider methods. Pass the model path (from `downloadModel()` or `getModelPath()`):
 
 ```typescript
-await model.download()
+import { llama, downloadModel } from '@react-native-ai/llama'
 
-console.log('Download complete!')
+// Download and get the path
+const modelPath = await downloadModel('ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf')
+
+// Create model with the path
+const languageModel = llama.languageModel(modelPath)
+
+// Embedding model
+const embeddingModel = llama.textEmbeddingModel(modelPath)
+
+// Speech model (requires vocoder)
+const speechModel = llama.speechModel(modelPath, {
+  vocoderPath: '/path/to/vocoder.gguf'
+})
 ```
 
-You can track download progress:
+With configuration options:
 
 ```typescript
-await model.download((progress) => {
-  console.log(`Download: ${progress.percentage}%`)
+const model = llama.languageModel(modelPath, {
+  contextParams: {
+    n_ctx: 4096, // Context window size (default: 2048)
+    n_gpu_layers: 99, // GPU layers for acceleration (default: 99)
+  },
 })
 ```
 
 ### Preparing Models
 
-After downloading, prepare the model for inference (loads it into memory):
+After creating a model instance, prepare it for inference (loads it into memory):
 
 ```typescript
 await model.prepare()
 ```
+
+> [!TIP]
+> Calling `prepare()` ahead of time is recommended for optimal performance. If not called, the model will auto-prepare when first used, but a warning will be logged.
 
 ### Using Models
 
@@ -154,51 +144,17 @@ Unload the model from memory to free resources:
 await model.unload()
 ```
 
-### Removing Downloaded Models
-
-Delete downloaded model files to free storage:
-
-```typescript
-await model.remove()
-```
-
-## Custom Storage Path
-
-By default, models are stored in `${DocumentDir}/llama-models/`. You can customize this:
-
-```typescript
-import { LlamaEngine } from '@react-native-ai/llama'
-
-LlamaEngine.setStoragePath('/custom/path/to/models')
-```
-
-Or when creating the provider:
-
-```typescript
-import { createLlamaProvider } from '@react-native-ai/llama'
-
-const llama = createLlamaProvider({
-  storagePath: '/custom/path/to/models',
-})
-```
-
 ## API Reference
-
-### `createLlamaProvider(options?)`
-
-Creates a customized Llama provider instance.
-
-- `options.storagePath`: Custom storage path for downloaded models
 
 ### `llama`
 
 Default provider instance with the following methods:
 
-### `llama.languageModel(modelId, options?)`
+### `llama.languageModel(modelPath, options?)`
 
 Creates a language model instance.
 
-- `modelId`: Model identifier in format `owner/repo/filename.gguf`
+- `modelPath`: Path to the model file (from `downloadModel()` or `getModelPath()`)
 - `options`:
   - `projectorPath`: Path to multimodal projector for vision/audio support
   - `projectorUseGpu`: Use GPU for multimodal processing (default: `true`)
@@ -206,11 +162,11 @@ Creates a language model instance.
     - `n_ctx`: Context size (default: 2048, or 4096 for multimodal)
     - `n_gpu_layers`: Number of GPU layers (default: 99)
 
-### `llama.textEmbeddingModel(modelId, options?)`
+### `llama.textEmbeddingModel(modelPath, options?)`
 
 Creates an embedding model instance.
 
-- `modelId`: Model identifier in format `owner/repo/filename.gguf`
+- `modelPath`: Path to the model file (from `downloadModel()` or `getModelPath()`)
 - `options`:
   - `normalize`: Normalize embeddings (default: -1)
   - `contextParams`: llama.rn context parameters
@@ -218,29 +174,46 @@ Creates an embedding model instance.
     - `n_gpu_layers`: Number of GPU layers (default: 99)
     - `n_parallel`: Parallel embeddings (default: 8)
 
-### `llama.speechModel(modelId, options)`
+### `llama.speechModel(modelPath, options)`
 
 Creates a speech model instance for text-to-speech.
 
-- `modelId`: Model identifier in format `owner/repo/filename.gguf`
+- `modelPath`: Path to the model file (from `downloadModel()` or `getModelPath()`)
 - `options`:
   - `vocoderPath`: **Required** - Path to vocoder model file
   - `vocoderBatchSize`: Batch size for vocoder processing
   - `contextParams`: llama.rn context parameters
 
-### `LlamaEngine`
+### Storage Functions
 
-- `getModels()`: Get list of downloaded models
-- `isDownloaded(modelId)`: Check if a model is downloaded
-- `setStoragePath(path)`: Set custom storage directory
+These functions are exported directly for model management. Models are stored in `${DocumentDir}/llama-models/`.
+
+### `downloadModel(modelId, progressCallback?)`
+
+Download a model from HuggingFace.
+
+- `modelId`: Model identifier in format `owner/repo/filename.gguf`
+- `progressCallback`: Optional callback with `{ percentage: number }`
+- Returns: `Promise<string>` - Path to the downloaded model file
+
+### `getModelPath(modelId)`
+
+Get the local file path for a model (without downloading).
+
+- `modelId`: Model identifier in format `owner/repo/filename.gguf`
+- Returns: `string` - Path where the model file is/would be stored
+
+### `isModelDownloaded(modelId)`
+
+Check if a model is downloaded.
+
+- `modelId`: Model identifier in format `owner/repo/filename.gguf`
+- Returns: `Promise<boolean>`
 
 ### Model Instance Methods
 
 All model types share these common methods:
 
-- `download(progressCallback?)`: Download model from HuggingFace
-- `isDownloaded()`: Check if this model is downloaded
 - `prepare()`: Initialize/load model into memory
 - `getContext()`: Get the underlying LlamaContext (for advanced usage)
 - `unload()`: Release model from memory
-- `remove()`: Delete model from disk


### PR DESCRIPTION
## Summary

Unifies the `prepare()` API across Apple and Llama providers, simplifies model management, and removes redundant APIs. This is part of the work I'm doing in the example application as well, wanted to bring both providers as closely together as possible.

**Apple LLM:**
- Added `prepare()` method to all model classes with auto-prepare + warning pattern
- Moved language configuration from `providerOptions` to constructor options
- Simplified provider methods to only accept options (removed modelId parameter)

**Llama:**
- Models now take file path instead of model ID - use `downloadModel()` or `getModelPath()` to get the path
- Removed methods from model classes: `download()`, `isDownloaded()`, `remove()`
- Removed `LlamaEngine` - use storage functions directly
- Auto-prepares with warning if `prepare()` not called ahead of time

**Storage API:**
- Simplified to fixed storage path (`${DocumentDir}/llama-models/`)
- Removed `setStoragePath()`, `getStoragePath()`, and `storagePath` parameter
- Exported `getModelPath()` for getting path without downloading

This will allow us to share Storage API with other runtimes and use it for other purposes in the future as well.

## New Usage Pattern

```typescript
// Llama
const modelPath = await downloadModel('owner/repo/model.gguf')
const model = llama.languageModel(modelPath)
await model.prepare()

// Apple
const model = apple.textEmbeddingModel({ language: 'en' })
await model.prepare()
```

## Breaking changes

language setting must be set for Apple provider in constructor, instead of per-call (which is more correct)
removed string argument for apple provider since only one value was accepted (I doubt this API had any real coverage, so decided to drop it to avoid introducing unnecessary legacy code at this point)