### PR TITLE
fix: emit text-start before completion to prevent first char being dropped

### DIFF
--- a/packages/llama/src/ai-sdk.ts
+++ b/packages/llama/src/ai-sdk.ts
@@ -426,9 +426,6 @@ export class LlamaLanguageModel implements LanguageModelV3 {
         try {
           let textId = generateId()
 
-          // Start in 'text' state and emit text-start immediately
-          // This fixes the issue where the first character/word was being dropped
-          // when text-start and text-delta were emitted synchronously in the same callback
           let state: LLMState = 'text' as LLMState
 
           controller.enqueue({
@@ -436,7 +433,6 @@ export class LlamaLanguageModel implements LanguageModelV3 {
             warnings: [],
           })
 
-          // Emit text-start before completion begins (matching apple-llm behavior)
           controller.enqueue({
             type: 'text-start',
             id: textId,
@@ -476,7 +472,6 @@ export class LlamaLanguageModel implements LanguageModelV3 {
                     })
                   }
 
-                  // After reasoning ends, emit text-start for subsequent text
                   state = 'text'
                   textId = generateId()
                   controller.enqueue({
@@ -486,8 +481,6 @@ export class LlamaLanguageModel implements LanguageModelV3 {
                   break
 
                 default:
-                  // process regular token
-
                   switch (state) {
                     case 'text':
                       // continue text block


### PR DESCRIPTION
When streaming text responses, the `doStream` method was emitting `text-start` and `text-delta` synchronously in the same callback invocation (when the first token arrived). This caused the AI SDK to miss processing the first `text-delta` event because the initialization triggered by `text-start` wasn't complete yet.

The fix matches the behavior of the `apple-llm` provider, which emits `text-start` immediately when the stream is created, before any tokens arrive.

## Test Plan

- [ ] Test `streamText` with llama provider - first character should no longer be missing
- [ ] Test responses that start with reasoning blocks (`<think>`) to ensure they still work correctly
- [ ] Test responses that contain reasoning in the middle

Fixes #171