### PR TITLE
fix(website): remove mistaken import statement in polyfills page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@react-native-ai/monorepo",
@@ -55,7 +56,6 @@
         "react": "19.1.0",
         "react-native": "0.81.4",
         "react-native-audio-api": "^0.7.1",
-        "react-native-blob-util": "^0.24.5",
         "react-native-bottom-tabs": "^0.11.0",
         "react-native-keyboard-controller": "1.18.5",
         "react-native-reanimated": "~4.1.0",

--- a/website/src/docs/polyfills.md
+++ b/website/src/docs/polyfills.md
@@ -1,7 +1,5 @@
 # Polyfills
 
-import { PackageManagerTabs } from '@theme'
-
 Several functions that are internally used by the AI SDK might not be available in the React Native runtime depending on your configuration and the target platform.
 
 ## Expo


### PR DESCRIPTION
I removed accidentally pasted import statement from the polyfills documentation.

<img width="887" height="215" alt="Screen Shot 2026-01-22 at 23 48 42 PM" src="https://github.com/user-attachments/assets/3439dff6-e0ba-4965-8366-1a625abdae0e" />
