### PR TITLE
fix: correct typo in multimodal section heading

### DIFF
--- a/website/src/docs/llama/generating.md
+++ b/website/src/docs/llama/generating.md
@@ -53,7 +53,7 @@ for await (const delta of textStream) {
 }
 ```
 
-## Multimodal (Vision andnd Audio)
+## Multimodal (Vision and Audio)
 
 The Llama provider supports multimodal models that can process images and audio. To enable multimodal capabilities, provide a `projectorPath` when creating the model:
 


### PR DESCRIPTION
I replaced "&" with a regular "and" because it's causing a static HTML entity in the sidebar (see attachment).
Probably this is a core rspress issue, or it may be fixed in  newer versions than the current one.
Anyway, this is a temporary fix until we determine the root cause or update to the latest rspress version.

<img width="248" height="41" alt="Screen Shot 2026-01-23 at 00 00 22 AM" src="https://github.com/user-attachments/assets/b57327b4-271b-459f-883a-6a1135f1df41" />
