### PR TITLE
refactor: rename isModelDownloaded to isLlamaModelDownloaded

### DIFF
--- a/apps/expo-example/src/components/adapters/llamaModelSetupAdapter.ts
+++ b/apps/expo-example/src/components/adapters/llamaModelSetupAdapter.ts
@@ -8,7 +8,7 @@ import {
   removeModel,
 } from '../../../../../packages/llama/src/storage'
 import type { Availability, SetupAdapter } from '../../config/providers.common'
-import { isModelDownloaded } from '../../utils/storage'
+import { isLlamaModelDownloaded } from '../../utils/llamaStorageUtils'
 
 export const createLlamaLanguageSetupAdapter = (
   hfModelId: string,
@@ -34,7 +34,7 @@ export const createLlamaLanguageSetupAdapter = (
     },
     builtIn: false,
     isAvailable(): Availability {
-      const downloaded = isModelDownloaded(hfModelId)
+      const downloaded = isLlamaModelDownloaded(hfModelId)
       return downloaded ? 'yes' : 'availableForDownload'
     },
     async download(onProgress) {

--- a/apps/expo-example/src/components/adapters/llamaSpeechSetupAdapter.ts
+++ b/apps/expo-example/src/components/adapters/llamaSpeechSetupAdapter.ts
@@ -7,7 +7,7 @@ import {
 } from '@react-native-ai/llama'
 
 import type { Availability, SetupAdapter } from '../../config/providers.common'
-import { isModelDownloaded } from '../../utils/storage'
+import { isLlamaModelDownloaded } from '../../utils/llamaStorageUtils'
 
 interface LlamaSpeechSetupOptions {
   modelId: string
@@ -42,15 +42,15 @@ export const createLlamaSpeechSetupAdapter = ({
     builtIn: false,
     isAvailable(): Availability {
       const [modelReady, vocoderReady] = [
-        isModelDownloaded(hfModelId),
-        isModelDownloaded(vocoderId),
+        isLlamaModelDownloaded(hfModelId),
+        isLlamaModelDownloaded(vocoderId),
       ]
       return modelReady && vocoderReady ? 'yes' : 'availableForDownload'
     },
     async download(onProgress) {
       const [modelReady, vocoderReady] = [
-        isModelDownloaded(hfModelId),
-        isModelDownloaded(vocoderId),
+        isLlamaModelDownloaded(hfModelId),
+        isLlamaModelDownloaded(vocoderId),
       ]
       if (!modelReady || !vocoderReady) {
         await downloadModel(hfModelId, (progress) => {

--- a/apps/expo-example/src/utils/llamaStorageUtils.ts
+++ b/apps/expo-example/src/utils/llamaStorageUtils.ts
@@ -1,7 +1,7 @@
 import { getModelPath } from '@react-native-ai/llama/src/storage'
 import { File } from 'expo-file-system'
 
-export function isModelDownloaded(modelId: string): boolean {
+export function isLlamaModelDownloaded(modelId: string): boolean {
   let path = getModelPath(modelId)
 
   // expo-file-system requires that this URI starts with the file:// protocol


### PR DESCRIPTION
This PR renames `isModelDownloaded` demo app util to `isLlamaModelDownloaded`. This utility exists because of the demo app design decision that `isAvailable` shall not be async, thus the builtin llama wrapper package utility cannot be used there as it's async. Therefore, the app carries its own sync expo-file-system based utility. The utility shall be named to verbosely specify it's only for the llama package.