### PR TITLE
feat(expo-example): add bielik 1.5b gguf preset

### DIFF
--- a/apps/expo-example/src/config/providers.common.ts
+++ b/apps/expo-example/src/config/providers.common.ts
@@ -45,6 +45,10 @@ export const commonLanguageAdapters: SetupAdapter<LanguageModelV3>[] = [
     'Qwen/Qwen2.5-3B-Instruct-GGUF/qwen2.5-3b-instruct-q3_k_m.gguf',
     toolDefinitions
   ),
+  createLlamaLanguageSetupAdapter(
+    'speakleash/Bielik-1.5B-v3.0-Instruct-GGUF/Bielik-1.5B-v3.0-Instruct.Q8_0.gguf',
+    toolDefinitions
+  ),
   createMLCLanguageSetupAdapter('Llama-3.2-1B-Instruct'),
   createMLCLanguageSetupAdapter('Llama-3.2-3B-Instruct'),
   createMLCLanguageSetupAdapter('Phi-3.5-mini-instruct'),


### PR DESCRIPTION
## Summary
- add official SpeakLeash Bielik 1.5B v3.0 GGUF preset to expo example language adapters
- wire Bielik with existing tool definitions for tool-capable flows

## Testing
- bun lint
