### PR TITLE
fix(dev-tools): ship dist/ to npm so Rozenite plugin loads

### DIFF
--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -6,6 +6,22 @@
   "main": "./dist/react-native.cjs",
   "module": "./dist/react-native.js",
   "types": "./dist/react-native.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/react-native.d.ts",
+      "import": "./dist/react-native.js",
+      "require": "./dist/react-native.cjs"
+    },
+    "./react-native": {
+      "types": "./dist/react-native.d.ts",
+      "import": "./dist/react-native.js",
+      "require": "./dist/react-native.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "clean": "del-cli dist",
     "dev": "rozenite dev",


### PR DESCRIPTION
Fixes #204.

## Summary

`@react-native-ai/dev-tools@0.12.0` is published to npm without a `dist/` folder, so Rozenite cannot discover the plugin (blank panel) and the documented import paths point at non-existent files. This PR fixes the packaging without touching any runtime code.

## Root cause

- The repo `.gitignore` excludes `dist/`.
- `packages/dev-tools/package.json` has no `"files"` field.
- When `npm publish` builds the tarball without a `"files"` whitelist, it respects `.gitignore` and strips `dist/`. The `prepare` script (`rozenite build`) does run, but its output is excluded from the tarball.
- Result: consumers get only `package.json` + sources, no `dist/rozenite.json`, no entry-point JS, no UI bundle. `main`/`module`/`types` all dangle.

The other symptoms reported in #204 are downstream of this:
- "Need to use `/react-native` subpath" — Metro happens to resolve `react-native.ts` source from the package root when `dist/` is absent.
- "react-json-tree missing" / "Invalid hook call" — only surface because users are forced to rebuild inside `node_modules`, where peer/dev separation breaks. `react-json-tree` is already correctly listed in `dependencies`.

Once `dist/` ships, all of these go away.

## Change

Single file: `packages/dev-tools/package.json`. Adds two top-level fields:

- `"files": ["dist"]` — whitelists the built artifact for the npm tarball, overriding `.gitignore`.
- `"exports"` — explicit map covering both `.` (the documented root import) and `./react-native` (the workaround users adopted from the issue thread). Both map to the same built entry, so there's no behavioral split. `./package.json` is exposed for tooling that introspects it. Existing `main`/`module`/`types` are kept untouched for older bundlers.

No source code, no docs, no version bump, no new dependencies.

## Verification

1. Clean rebuild produces the expected dist:
   ```
   rm -rf dist && bun run prepare
   ```
   Confirmed `dist/rozenite.json`, `dist/react-native.{js,cjs,d.ts}`, `dist/App.html`, `dist/assets/App-*.js`, plus per-function entries and `dist/src/**/*.d.ts`.

2. `npm pack --dry-run` tarball (25 files, 169 KB packed / 850 KB unpacked) now includes:
   - `dist/rozenite.json` ✓ (Rozenite plugin manifest — fixes blank panel)
   - `dist/react-native.{js,cjs,d.ts}` ✓ (entry points for the documented root import)
   - `dist/App.html` + `dist/assets/App-*.js` ✓ (UI bundle)
   - `dist/{getAiSdkTracer,useAiSdkDevTools,telemetry-recorder}.{js,cjs}` ✓
   - `dist/src/**/*.d.ts` ✓ (type declarations referenced by `react-native.d.ts`)
   - `LICENSE`, `README.md`, `package.json` (auto-included)

   And correctly excludes `src/`, `react-native.ts`, `vite.config.ts`, `rozenite.config.ts`, `tsconfig.json` — those are build inputs, not runtime artifacts.

3. Node resolver on the published shape resolves both:
   - `@react-native-ai/dev-tools` → `dist/react-native.cjs`
   - `@react-native-ai/dev-tools/react-native` → `dist/react-native.cjs`
