### PR TITLE
fix: think token splitting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,12 @@ export default defineConfig([
       },
     },
   },
+  {
+    files: ['**/__tests__/**/*.{ts,tsx,js,jsx}'],
+    settings: {
+      'import/core-modules': ['bun:test'],
+    },
+  },
   // Configure Prettier
   {
     rules: {

--- a/packages/llama/src/__tests__/streamParser.test.ts
+++ b/packages/llama/src/__tests__/streamParser.test.ts
@@ -1,0 +1,376 @@
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import { describe, expect, test } from 'bun:test'
+import type { TokenData } from 'llama.rn'
+
+import { createLlamaStreamParser } from '../streamParser'
+
+function runParser(tokens: TokenData[]): LanguageModelV3StreamPart[] {
+  const parts: LanguageModelV3StreamPart[] = []
+  const parser = createLlamaStreamParser({
+    enqueue: (part) => parts.push(part),
+  })
+
+  for (const token of tokens) {
+    parser.processToken(token)
+  }
+
+  parser.finish()
+
+  return parts
+}
+
+describe('createLlamaStreamParser', () => {
+  test('handles split <think> delimiters as reasoning boundaries', () => {
+    const parts = runParser([
+      { token: '<' },
+      { token: 'think' },
+      { token: '>' },
+      { token: 'reasoning text' },
+      { token: '</' },
+      { token: 'think' },
+      { token: '>' },
+      { token: 'final answer' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'reasoning-start',
+      'reasoning-delta',
+      'reasoning-end',
+      'text-start',
+      'text-delta',
+      'text-end',
+    ])
+
+    expect(
+      parts.filter((part) => part.type === 'reasoning-start')
+    ).toHaveLength(1)
+
+    expect(
+      parts
+        .filter(
+          (
+            part
+          ): part is Extract<
+            LanguageModelV3StreamPart,
+            { type: 'reasoning-delta' }
+          > => part.type === 'reasoning-delta'
+        )
+        .map((part) => part.delta)
+        .join('')
+    ).toBe('reasoning text')
+
+    expect(
+      parts
+        .filter(
+          (
+            part
+          ): part is Extract<
+            LanguageModelV3StreamPart,
+            { type: 'text-delta' }
+          > => part.type === 'text-delta'
+        )
+        .map((part) => part.delta)
+        .join('')
+    ).toBe('final answer')
+  })
+
+  test('handles markers embedded in a reasoning chunk', () => {
+    const parts = runParser([
+      { token: '<think>' },
+      { token: 'reasoning text</think>' },
+      { token: 'final answer' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'reasoning-start',
+      'reasoning-delta',
+      'reasoning-end',
+      'text-start',
+      'text-delta',
+      'text-end',
+    ])
+
+    expect(
+      parts
+        .filter(
+          (
+            part
+          ): part is Extract<
+            LanguageModelV3StreamPart,
+            { type: 'reasoning-delta' }
+          > => part.type === 'reasoning-delta'
+        )
+        .map((part) => part.delta)
+        .join('')
+    ).toBe('reasoning text')
+
+    expect(
+      parts
+        .filter(
+          (
+            part
+          ): part is Extract<
+            LanguageModelV3StreamPart,
+            { type: 'text-delta' }
+          > => part.type === 'text-delta'
+        )
+        .map((part) => part.delta)
+        .join('')
+    ).toBe('final answer')
+  })
+
+  test('handles start and end markers inside a single chunk', () => {
+    const parts = runParser([
+      { token: '<think>reasoning text</think>final answer' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'reasoning-start',
+      'reasoning-delta',
+      'reasoning-end',
+      'text-start',
+      'text-delta',
+      'text-end',
+    ])
+
+    expect(
+      parts
+        .filter(
+          (
+            part
+          ): part is Extract<
+            LanguageModelV3StreamPart,
+            { type: 'reasoning-delta' }
+          > => part.type === 'reasoning-delta'
+        )
+        .map((part) => part.delta)
+        .join('')
+    ).toBe('reasoning text')
+
+    expect(
+      parts
+        .filter(
+          (
+            part
+          ): part is Extract<
+            LanguageModelV3StreamPart,
+            { type: 'text-delta' }
+          > => part.type === 'text-delta'
+        )
+        .map((part) => part.delta)
+        .join('')
+    ).toBe('final answer')
+  })
+
+  test('keeps baseline behavior when <think> arrives as full tokens', () => {
+    const parts = runParser([
+      { token: '<think>' },
+      { token: 'reasoning text' },
+      { token: '</think>' },
+      { token: 'final answer' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'reasoning-start',
+      'reasoning-delta',
+      'reasoning-end',
+      'text-start',
+      'text-delta',
+      'text-end',
+    ])
+
+    expect(
+      parts.filter((part) => part.type === 'reasoning-start')
+    ).toHaveLength(1)
+  })
+
+  test('does not leak partial placeholder prefixes into text output', () => {
+    const parts = runParser([
+      { token: '<' },
+      { token: 'thi' },
+      { token: 'nk>' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'reasoning-start',
+      'reasoning-end',
+    ])
+  })
+
+  test('does not duplicate accumulated tool calls with ids', () => {
+    const parts = runParser([
+      { token: '<tool_call>' },
+      {
+        token: '{',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+        ],
+      },
+      {
+        token: '}',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+        ],
+      },
+      { token: '</tool_call>' },
+    ])
+
+    const toolCalls = parts.filter((part) => part.type === 'tool-call')
+
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'tool-1',
+      toolName: 'search',
+      input: '{"query":"react native"}',
+    })
+  })
+
+  test('preserves distinct no-id tool calls with identical payloads', () => {
+    const parts = runParser([
+      { token: '<tool_call>' },
+      {
+        token: '{',
+        tool_calls: [
+          {
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+          {
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+        ],
+      },
+      { token: '</tool_call>' },
+    ])
+
+    const toolCalls = parts.filter((part) => part.type === 'tool-call')
+
+    expect(toolCalls).toHaveLength(2)
+  })
+
+  test('emits tool calls at the closing marker boundary before resumed text', () => {
+    const parts = runParser([
+      { token: '<tool_call>' },
+      {
+        token: '{"query":"react native"}',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+        ],
+      },
+      { token: '</tool_call>final answer' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'tool-call',
+      'text-start',
+      'text-delta',
+      'text-end',
+    ])
+  })
+
+  test('handles split opening <tool_call> delimiters without leaking marker text', () => {
+    const parts = runParser([
+      { token: '<tool' },
+      { token: '_call>' },
+      {
+        token: '{"query":"react native"}',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+        ],
+      },
+      { token: '</tool_call>' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual(['tool-call'])
+
+    const toolCalls = parts.filter((part) => part.type === 'tool-call')
+
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'tool-1',
+      toolName: 'search',
+      input: '{"query":"react native"}',
+    })
+  })
+
+  test('handles split closing </tool_call> delimiters before resuming text', () => {
+    const parts = runParser([
+      { token: '<tool_call>' },
+      {
+        token: '{"query":"react native"}',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+        ],
+      },
+      { token: '</tool' },
+      { token: '_call>final answer' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'tool-call',
+      'text-start',
+      'text-delta',
+      'text-end',
+    ])
+
+    const toolCalls = parts.filter((part) => part.type === 'tool-call')
+    const textDeltas = parts.filter((part) => part.type === 'text-delta')
+
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'tool-1',
+      toolName: 'search',
+      input: '{"query":"react native"}',
+    })
+    expect(textDeltas).toHaveLength(1)
+    expect(textDeltas[0]).toMatchObject({
+      type: 'text-delta',
+      delta: 'final answer',
+    })
+  })
+})

--- a/packages/llama/src/__tests__/streamParser.test.ts
+++ b/packages/llama/src/__tests__/streamParser.test.ts
@@ -373,4 +373,62 @@ describe('createLlamaStreamParser', () => {
       delta: 'final answer',
     })
   })
+
+  test('treats thinking markers inside tool-call payload as opaque text', () => {
+    const parts = runParser([
+      { token: '<tool_call>' },
+      {
+        token: '{"query":"what does <think>reasoning</think> mean?"}',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"what does <think>reasoning</think> mean?"}',
+            },
+          },
+        ],
+      },
+      { token: '</tool_call>' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual(['tool-call'])
+    expect(parts[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'tool-1',
+      toolName: 'search',
+      input: '{"query":"what does <think>reasoning</think> mean?"}',
+    })
+  })
+
+  test('treats split thinking markers inside tool-call payload as opaque text', () => {
+    const parts = runParser([
+      { token: '<tool_call>' },
+      { token: '{"query":"what does <thi' },
+      { token: 'nk>reasoning</thi' },
+      {
+        token: 'nk> mean?"}',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"what does <think>reasoning</think> mean?"}',
+            },
+          },
+        ],
+      },
+      { token: '</tool_call>' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual(['tool-call'])
+    expect(parts[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'tool-1',
+      toolName: 'search',
+      input: '{"query":"what does <think>reasoning</think> mean?"}',
+    })
+  })
 })

--- a/packages/llama/src/ai-sdk.ts
+++ b/packages/llama/src/ai-sdk.ts
@@ -22,10 +22,9 @@ import {
   type LlamaContext,
   type NativeCompletionResult,
   type NativeEmbeddingResult,
-  type TokenData,
 } from 'llama.rn'
 
-type LLMState = 'text' | 'reasoning' | 'tool-call' | 'none'
+import { createLlamaStreamParser } from './streamParser'
 
 interface LLMMessagePart {
   type: 'text' | 'image_url' | 'input_audio'
@@ -246,12 +245,6 @@ export interface LlamaModelOptions {
    */
   contextParams?: Partial<ContextParams>
 }
-
-const START_OF_THINKING_PLACEHOLDER = '<think>'
-const END_OF_THINKING_PLACEHOLDER = '</think>'
-
-const START_OF_TOOL_CALL_PLACEHOLDER = '<tool_call>'
-const END_OF_TOOL_CALL_PLACEHOLDER = '</tool_call>'
 
 /**
  * llama.rn Language Model for AI SDK
@@ -520,111 +513,23 @@ export class LlamaLanguageModel implements LanguageModelV3 {
     const stream = new ReadableStream<LanguageModelV3StreamPart>({
       start: async (controller) => {
         try {
-          let currentChunkId = generateId()
-
-          let state: LLMState = 'none' as LLMState
+          const streamParser = createLlamaStreamParser({
+            enqueue: (part) => controller.enqueue(part),
+          })
 
           controller.enqueue({
             type: 'stream-start',
             warnings: [],
           })
 
-          const finishCurrentBlock = () => {
-            if (state === 'text') {
-              controller.enqueue({
-                type: 'text-end',
-                id: currentChunkId,
-              })
-            }
-            if (state === 'reasoning') {
-              controller.enqueue({
-                type: 'reasoning-end',
-                id: currentChunkId,
-              })
-            }
-            state = 'none'
-          }
-
           const result = await context.completion(
             completionOptions,
-            (tokenData: TokenData) => {
-              const { token } = tokenData
-
-              switch (token) {
-                case START_OF_THINKING_PLACEHOLDER: {
-                  finishCurrentBlock()
-                  state = 'reasoning'
-                  currentChunkId = generateId()
-                  controller.enqueue({
-                    type: 'reasoning-start',
-                    id: currentChunkId,
-                  })
-                  break
-                }
-                case START_OF_TOOL_CALL_PLACEHOLDER: {
-                  finishCurrentBlock()
-                  state = 'tool-call'
-                  break
-                }
-                case END_OF_TOOL_CALL_PLACEHOLDER: {
-                  finishCurrentBlock()
-                  for (const toolCall of tokenData.tool_calls ?? []) {
-                    controller.enqueue({
-                      type: 'tool-call',
-                      toolCallId: toolCall.id ?? generateId(),
-                      toolName: toolCall.function.name,
-                      input: toolCall.function.arguments,
-                    })
-                  }
-                  break
-                }
-                case END_OF_THINKING_PLACEHOLDER: {
-                  finishCurrentBlock()
-                  break
-                }
-                default:
-                  switch (state) {
-                    case 'none': {
-                      state = 'text'
-                      currentChunkId = generateId()
-                      controller.enqueue({
-                        type: 'text-start',
-                        id: currentChunkId,
-                      })
-                      controller.enqueue({
-                        type: 'text-delta',
-                        id: currentChunkId,
-                        delta: token,
-                      })
-                      break
-                    }
-                    case 'text': {
-                      controller.enqueue({
-                        type: 'text-delta',
-                        id: currentChunkId,
-                        delta: token,
-                      })
-                      break
-                    }
-                    case 'reasoning': {
-                      controller.enqueue({
-                        type: 'reasoning-delta',
-                        id: currentChunkId,
-                        delta: token,
-                      })
-                      break
-                    }
-                    case 'tool-call': {
-                      // Ignore tokens while in tool-call state; tool call data
-                      // is handled via tokenData.tool_calls at the end marker.
-                      break
-                    }
-                  }
-              }
+            (tokenData) => {
+              streamParser.processToken(tokenData)
             }
           )
 
-          finishCurrentBlock()
+          streamParser.finish()
 
           controller.enqueue({
             type: 'finish',

--- a/packages/llama/src/streamParser.ts
+++ b/packages/llama/src/streamParser.ts
@@ -17,6 +17,8 @@ const PLACEHOLDERS = [
   END_OF_TOOL_CALL_PLACEHOLDER,
 ] as const
 
+type Placeholder = (typeof PLACEHOLDERS)[number]
+
 const MAX_PLACEHOLDER_LENGTH = Math.max(
   ...PLACEHOLDERS.map((value) => value.length)
 )
@@ -30,14 +32,17 @@ export interface LlamaStreamParser {
   finish: () => void
 }
 
-function getLongestPlaceholderPrefixSuffix(value: string): string {
+function getLongestPlaceholderPrefixSuffix(
+  value: string,
+  placeholders: readonly Placeholder[] = PLACEHOLDERS
+): string {
   for (
     let length = Math.min(value.length, MAX_PLACEHOLDER_LENGTH);
     length > 0;
     length -= 1
   ) {
     const suffix = value.slice(-length)
-    if (PLACEHOLDERS.some((placeholder) => placeholder.startsWith(suffix))) {
+    if (placeholders.some((placeholder) => placeholder.startsWith(suffix))) {
       return suffix
     }
   }
@@ -45,11 +50,16 @@ function getLongestPlaceholderPrefixSuffix(value: string): string {
   return ''
 }
 
-function getFirstPlaceholderMatch(value: string) {
-  const matches = PLACEHOLDERS.map((placeholder) => ({
-    placeholder,
-    index: value.indexOf(placeholder),
-  })).filter(({ index }) => index !== -1)
+function getFirstPlaceholderMatch(
+  value: string,
+  placeholders: readonly Placeholder[] = PLACEHOLDERS
+) {
+  const matches = placeholders
+    .map((placeholder) => ({
+      placeholder,
+      index: value.indexOf(placeholder),
+    }))
+    .filter(({ index }) => index !== -1)
 
   if (matches.length === 0) {
     return null
@@ -152,7 +162,7 @@ export function createLlamaStreamParser(
     pendingToolCalls = []
   }
 
-  const handlePlaceholder = (placeholder: (typeof PLACEHOLDERS)[number]) => {
+  const handlePlaceholder = (placeholder: Placeholder) => {
     if (placeholder === START_OF_THINKING_PLACEHOLDER) {
       finishCurrentBlock()
       state = 'reasoning'
@@ -181,7 +191,12 @@ export function createLlamaStreamParser(
 
   const flushBuffer = (force = false) => {
     while (pendingText.length > 0) {
-      const placeholderMatch = getFirstPlaceholderMatch(pendingText)
+      const activePlaceholders: readonly Placeholder[] =
+        state === 'tool-call' ? [END_OF_TOOL_CALL_PLACEHOLDER] : PLACEHOLDERS
+      const placeholderMatch = getFirstPlaceholderMatch(
+        pendingText,
+        activePlaceholders
+      )
 
       if (placeholderMatch) {
         const { placeholder, index } = placeholderMatch
@@ -194,7 +209,10 @@ export function createLlamaStreamParser(
         continue
       }
 
-      const pendingPrefix = getLongestPlaceholderPrefixSuffix(pendingText)
+      const pendingPrefix = getLongestPlaceholderPrefixSuffix(
+        pendingText,
+        activePlaceholders
+      )
       const flushableLength = pendingText.length - pendingPrefix.length
 
       if (!force && flushableLength <= 0) {

--- a/packages/llama/src/streamParser.ts
+++ b/packages/llama/src/streamParser.ts
@@ -1,0 +1,232 @@
+import type { LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import { generateId } from '@ai-sdk/provider-utils'
+import type { TokenData } from 'llama.rn'
+
+export type LLMState = 'text' | 'reasoning' | 'tool-call' | 'none'
+
+export const START_OF_THINKING_PLACEHOLDER = '<think>'
+export const END_OF_THINKING_PLACEHOLDER = '</think>'
+
+export const START_OF_TOOL_CALL_PLACEHOLDER = '<tool_call>'
+export const END_OF_TOOL_CALL_PLACEHOLDER = '</tool_call>'
+
+const PLACEHOLDERS = [
+  START_OF_THINKING_PLACEHOLDER,
+  END_OF_THINKING_PLACEHOLDER,
+  START_OF_TOOL_CALL_PLACEHOLDER,
+  END_OF_TOOL_CALL_PLACEHOLDER,
+] as const
+
+const MAX_PLACEHOLDER_LENGTH = Math.max(
+  ...PLACEHOLDERS.map((value) => value.length)
+)
+
+export interface StreamPartSink {
+  enqueue: (part: LanguageModelV3StreamPart) => void
+}
+
+export interface LlamaStreamParser {
+  processToken: (tokenData: TokenData) => void
+  finish: () => void
+}
+
+function getLongestPlaceholderPrefixSuffix(value: string): string {
+  for (
+    let length = Math.min(value.length, MAX_PLACEHOLDER_LENGTH);
+    length > 0;
+    length -= 1
+  ) {
+    const suffix = value.slice(-length)
+    if (PLACEHOLDERS.some((placeholder) => placeholder.startsWith(suffix))) {
+      return suffix
+    }
+  }
+
+  return ''
+}
+
+function getFirstPlaceholderMatch(value: string) {
+  const matches = PLACEHOLDERS.map((placeholder) => ({
+    placeholder,
+    index: value.indexOf(placeholder),
+  })).filter(({ index }) => index !== -1)
+
+  if (matches.length === 0) {
+    return null
+  }
+
+  return matches.reduce((earliest, current) => {
+    if (current.index < earliest.index) {
+      return current
+    }
+
+    return earliest
+  })
+}
+
+export function createLlamaStreamParser(
+  sink: StreamPartSink
+): LlamaStreamParser {
+  let currentChunkId = generateId()
+  let state: LLMState = 'none'
+  let pendingText = ''
+  let pendingToolCallIds = new Set<string>()
+  let pendingToolCalls: NonNullable<TokenData['tool_calls']> = []
+
+  const finishCurrentBlock = () => {
+    if (state === 'text') {
+      sink.enqueue({
+        type: 'text-end',
+        id: currentChunkId,
+      })
+    }
+    if (state === 'reasoning') {
+      sink.enqueue({
+        type: 'reasoning-end',
+        id: currentChunkId,
+      })
+    }
+    state = 'none'
+  }
+
+  const emitDelta = (delta: string) => {
+    if (!delta) {
+      return
+    }
+
+    if (state === 'tool-call') {
+      return
+    }
+
+    if (state === 'none') {
+      state = 'text'
+      currentChunkId = generateId()
+      sink.enqueue({
+        type: 'text-start',
+        id: currentChunkId,
+      })
+    }
+
+    if (state === 'text') {
+      sink.enqueue({
+        type: 'text-delta',
+        id: currentChunkId,
+        delta,
+      })
+      return
+    }
+
+    sink.enqueue({
+      type: 'reasoning-delta',
+      id: currentChunkId,
+      delta,
+    })
+  }
+
+  const queueToolCalls = (toolCalls: TokenData['tool_calls']) => {
+    for (const toolCall of toolCalls ?? []) {
+      if (!toolCall.id) {
+        pendingToolCalls.push(toolCall)
+        continue
+      }
+
+      if (pendingToolCallIds.has(toolCall.id)) {
+        continue
+      }
+
+      pendingToolCallIds.add(toolCall.id)
+      pendingToolCalls.push(toolCall)
+    }
+  }
+
+  const emitPendingToolCalls = () => {
+    for (const toolCall of pendingToolCalls) {
+      sink.enqueue({
+        type: 'tool-call',
+        toolCallId: toolCall.id ?? generateId(),
+        toolName: toolCall.function.name,
+        input: toolCall.function.arguments,
+      })
+    }
+    pendingToolCallIds.clear()
+    pendingToolCalls = []
+  }
+
+  const handlePlaceholder = (placeholder: (typeof PLACEHOLDERS)[number]) => {
+    if (placeholder === START_OF_THINKING_PLACEHOLDER) {
+      finishCurrentBlock()
+      state = 'reasoning'
+      currentChunkId = generateId()
+      sink.enqueue({
+        type: 'reasoning-start',
+        id: currentChunkId,
+      })
+      return
+    }
+
+    if (placeholder === END_OF_THINKING_PLACEHOLDER) {
+      finishCurrentBlock()
+      return
+    }
+
+    if (placeholder === START_OF_TOOL_CALL_PLACEHOLDER) {
+      finishCurrentBlock()
+      state = 'tool-call'
+      return
+    }
+
+    finishCurrentBlock()
+    emitPendingToolCalls()
+  }
+
+  const flushBuffer = (force = false) => {
+    while (pendingText.length > 0) {
+      const placeholderMatch = getFirstPlaceholderMatch(pendingText)
+
+      if (placeholderMatch) {
+        const { placeholder, index } = placeholderMatch
+        const prefix = pendingText.slice(0, index)
+        if (prefix) {
+          emitDelta(prefix)
+        }
+        pendingText = pendingText.slice(index + placeholder.length)
+        handlePlaceholder(placeholder)
+        continue
+      }
+
+      const pendingPrefix = getLongestPlaceholderPrefixSuffix(pendingText)
+      const flushableLength = pendingText.length - pendingPrefix.length
+
+      if (!force && flushableLength <= 0) {
+        return
+      }
+
+      const flushUntil = force ? pendingText.length : flushableLength
+      const flushableText = pendingText.slice(0, flushUntil)
+      pendingText = pendingText.slice(flushUntil)
+      emitDelta(flushableText)
+    }
+  }
+
+  const processToken = (tokenData: TokenData) => {
+    if (tokenData.tool_calls?.length) {
+      queueToolCalls(tokenData.tool_calls)
+    }
+
+    pendingText += tokenData.token
+    flushBuffer(false)
+  }
+
+  return {
+    processToken,
+    finish: () => {
+      flushBuffer(true)
+      if (state === 'tool-call') {
+        finishCurrentBlock()
+        emitPendingToolCalls()
+        return
+      }
+      finishCurrentBlock()
+    },
+  }
+}

--- a/packages/llama/tsconfig.json
+++ b/packages/llama/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**"]
 }


### PR DESCRIPTION
Related issue - [#199](https://github.com/callstackincubator/ai/issues/199)

## Summary
Makes the `@react-native-ai/llama` streaming parser resilient to split reasoning and tool-call delimiters.
Previously, the fallback stream adapter assumed markers like `<think>`, `</think>`, `<tool_call>`, and `</tool_call>` arrived as whole tokens. When tokenization split those markers across multiple streamed chunks, the parser could miss the transition entirely and leak reasoning or marker text into normal output.
This change extracts the stream state machine into a dedicated helper and updates it to buffer possible placeholder fragments, detect markers even when they are split or embedded inside a larger chunk, and preserve normal text/tool-call behavior.

## Changes
- Extract the llama stream state machine into `createLlamaStreamParser`
- Replace inline `doStream()` parsing with the extracted parser helper
- Buffer partial placeholder fragments across streamed chunks
- Detect placeholders even when they appear inside a larger chunk
- Handle split `<think>` / `</think>` delimiters correctly
- Keep normal text streaming behavior intact when no structured markers are present
- Preserve tool-call behavior while handling split `<tool_call>` / `</tool_call>` markers
- Avoid duplicate emission for accumulated tool calls with ids
- Preserve distinct no-id tool calls with identical payloads
- Exclude package test files from `packages/llama` typecheck/build inputs
- Add test-only lint override for Bun-based tests

## Testing
- Ran `bun test packages/llama/src/__tests__/streamParser.test.ts`
- Ran `./node_modules/.bin/tsc --noEmit --project packages/llama/tsconfig.json`
- Ran `./node_modules/.bin/tsc --noEmit --project packages/llama/tsconfig.build.json`
- Ran `bun lint`
- Verified on iOS device that previously reproduced `<think>` delimiter-splitting leakage no longer appears
- Added regression coverage for:
  - split `<think>` / `</think>` markers
  - embedded markers inside a reasoning chunk
  - single-chunk `<think>reasoning</think>final answer`
  - split opening and closing `<tool_call>` markers
  - tool-call accumulation / dedupe behavior