### PR TITLE
fix: native llama reasoning stream and provider options

### DIFF
--- a/packages/llama/src/__tests__/completionOptions.test.ts
+++ b/packages/llama/src/__tests__/completionOptions.test.ts
@@ -1,0 +1,48 @@
+import type { LanguageModelV3CallOptions } from '@ai-sdk/provider'
+import { describe, expect, test } from 'bun:test'
+
+import { buildLlamaCompletionOptions } from '../completionOptions'
+
+function createCallOptions(
+  providerOptions?: Record<string, unknown>
+): LanguageModelV3CallOptions {
+  return {
+    prompt: [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    ],
+    inputFormat: 'messages',
+    mode: {
+      type: 'regular',
+    },
+    providerOptions,
+  }
+}
+
+describe('buildLlamaCompletionOptions', () => {
+  test('forwards providerOptions.llama values', () => {
+    const completionOptions = buildLlamaCompletionOptions(
+      createCallOptions({
+        llama: {
+          enable_thinking: true,
+          reasoning_format: 'deepseek',
+        },
+      }),
+      []
+    )
+
+    expect(completionOptions.enable_thinking).toBe(true)
+    expect(completionOptions.reasoning_format).toBe('deepseek')
+  })
+
+  test('keeps default reasoning_format when providerOptions.llama is absent', () => {
+    const completionOptions = buildLlamaCompletionOptions(
+      createCallOptions(),
+      []
+    )
+
+    expect(completionOptions.reasoning_format).toBe('auto')
+  })
+})

--- a/packages/llama/src/__tests__/streamParser.test.ts
+++ b/packages/llama/src/__tests__/streamParser.test.ts
@@ -402,10 +402,36 @@ describe('createLlamaStreamParser', () => {
     ])
 
     expect(parts.map((part) => part.type)).toEqual([
+      'tool-call',
       'text-start',
       'text-delta',
       'text-end',
+    ])
+  })
+
+  test('emits native tool calls at the closing marker boundary before resumed text', () => {
+    const parts = runParser([
+      {
+        token: '</tool_call>final answer',
+        content: 'final answer',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+        ],
+      },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
       'tool-call',
+      'text-start',
+      'text-delta',
+      'text-end',
     ])
   })
 

--- a/packages/llama/src/__tests__/streamParser.test.ts
+++ b/packages/llama/src/__tests__/streamParser.test.ts
@@ -20,7 +20,95 @@ function runParser(tokens: TokenData[]): LanguageModelV3StreamPart[] {
 }
 
 describe('createLlamaStreamParser', () => {
-  test('handles split <think> delimiters as reasoning boundaries', () => {
+  test('prefers native reasoning/content fields and emits deltas from accumulated values', () => {
+    const parts = runParser([
+      { token: '', reasoning_content: 'Let me' },
+      { token: '', reasoning_content: 'Let me think' },
+      { token: '', content: 'Final' },
+      { token: '', content: 'Final answer' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'reasoning-start',
+      'reasoning-delta',
+      'reasoning-delta',
+      'reasoning-end',
+      'text-start',
+      'text-delta',
+      'text-delta',
+      'text-end',
+    ])
+
+    const reasoningDeltas = parts.filter(
+      (
+        part
+      ): part is Extract<
+        LanguageModelV3StreamPart,
+        { type: 'reasoning-delta' }
+      > => part.type === 'reasoning-delta'
+    )
+    const textDeltas = parts.filter(
+      (
+        part
+      ): part is Extract<LanguageModelV3StreamPart, { type: 'text-delta' }> =>
+        part.type === 'text-delta'
+    )
+
+    expect(reasoningDeltas.map((part) => part.delta)).toEqual([
+      'Let me',
+      ' think',
+    ])
+    expect(textDeltas.map((part) => part.delta)).toEqual(['Final', ' answer'])
+  })
+
+  test('does not duplicate output when native fields and raw tokens coexist on the same chunk', () => {
+    const parts = runParser([
+      { token: 'Let me', reasoning_content: 'Let me' },
+      { token: ' think', reasoning_content: 'Let me think' },
+      { token: 'Final', content: 'Final' },
+      { token: ' answer', content: 'Final answer' },
+    ])
+
+    const reasoningDeltas = parts.filter(
+      (
+        part
+      ): part is Extract<
+        LanguageModelV3StreamPart,
+        { type: 'reasoning-delta' }
+      > => part.type === 'reasoning-delta'
+    )
+    const textDeltas = parts.filter(
+      (
+        part
+      ): part is Extract<LanguageModelV3StreamPart, { type: 'text-delta' }> =>
+        part.type === 'text-delta'
+    )
+
+    expect(reasoningDeltas.map((part) => part.delta)).toEqual([
+      'Let me',
+      ' think',
+    ])
+    expect(textDeltas.map((part) => part.delta)).toEqual(['Final', ' answer'])
+  })
+
+  test('flushes buffered fallback text even after native chunks appeared', () => {
+    const parts = runParser([
+      { token: '', content: 'Final' },
+      { token: '<' },
+      { token: 'think' },
+      { token: '>' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'text-start',
+      'text-delta',
+      'text-end',
+      'reasoning-start',
+      'reasoning-end',
+    ])
+  })
+
+  test('falls back to placeholder parsing when native fields are absent', () => {
     const parts = runParser([
       { token: '<' },
       { token: 'think' },
@@ -40,38 +128,6 @@ describe('createLlamaStreamParser', () => {
       'text-delta',
       'text-end',
     ])
-
-    expect(
-      parts.filter((part) => part.type === 'reasoning-start')
-    ).toHaveLength(1)
-
-    expect(
-      parts
-        .filter(
-          (
-            part
-          ): part is Extract<
-            LanguageModelV3StreamPart,
-            { type: 'reasoning-delta' }
-          > => part.type === 'reasoning-delta'
-        )
-        .map((part) => part.delta)
-        .join('')
-    ).toBe('reasoning text')
-
-    expect(
-      parts
-        .filter(
-          (
-            part
-          ): part is Extract<
-            LanguageModelV3StreamPart,
-            { type: 'text-delta' }
-          > => part.type === 'text-delta'
-        )
-        .map((part) => part.delta)
-        .join('')
-    ).toBe('final answer')
   })
 
   test('handles markers embedded in a reasoning chunk', () => {
@@ -117,6 +173,63 @@ describe('createLlamaStreamParser', () => {
         .map((part) => part.delta)
         .join('')
     ).toBe('final answer')
+  })
+
+  test('keeps <think> markers inside tool-call payload text untouched', () => {
+    const parts = runParser([
+      { token: '<tool_call>' },
+      {
+        token: '{"prompt":"<think>do not parse</think>"}',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"prompt":"<think>do not parse</think>"}',
+            },
+          },
+        ],
+      },
+      { token: '</tool_call>' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual(['tool-call'])
+    expect(parts[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'tool-1',
+      toolName: 'search',
+      input: '{"prompt":"<think>do not parse</think>"}',
+    })
+  })
+
+  test('keeps split <think> markers inside tool-call payload text untouched', () => {
+    const parts = runParser([
+      { token: '<tool_call>' },
+      {
+        token: '{"prompt":"<thi',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"prompt":"<think>do not parse</think>"}',
+            },
+          },
+        ],
+      },
+      { token: 'nk>do not parse</think>"}' },
+      { token: '</tool_call>' },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual(['tool-call'])
+    expect(parts[0]).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'tool-1',
+      toolName: 'search',
+      input: '{"prompt":"<think>do not parse</think>"}',
+    })
   })
 
   test('handles start and end markers inside a single chunk', () => {
@@ -270,6 +383,32 @@ describe('createLlamaStreamParser', () => {
     expect(toolCalls).toHaveLength(2)
   })
 
+  test('emits tool calls queued on native chunks even without tool-call state', () => {
+    const parts = runParser([
+      {
+        token: '<tool_call>{"query":"react native"}</tool_call>',
+        content: 'Final answer',
+        tool_calls: [
+          {
+            id: 'tool-1',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: '{"query":"react native"}',
+            },
+          },
+        ],
+      },
+    ])
+
+    expect(parts.map((part) => part.type)).toEqual([
+      'text-start',
+      'text-delta',
+      'text-end',
+      'tool-call',
+    ])
+  })
+
   test('emits tool calls at the closing marker boundary before resumed text', () => {
     const parts = runParser([
       { token: '<tool_call>' },
@@ -371,64 +510,6 @@ describe('createLlamaStreamParser', () => {
     expect(textDeltas[0]).toMatchObject({
       type: 'text-delta',
       delta: 'final answer',
-    })
-  })
-
-  test('treats thinking markers inside tool-call payload as opaque text', () => {
-    const parts = runParser([
-      { token: '<tool_call>' },
-      {
-        token: '{"query":"what does <think>reasoning</think> mean?"}',
-        tool_calls: [
-          {
-            id: 'tool-1',
-            type: 'function',
-            function: {
-              name: 'search',
-              arguments: '{"query":"what does <think>reasoning</think> mean?"}',
-            },
-          },
-        ],
-      },
-      { token: '</tool_call>' },
-    ])
-
-    expect(parts.map((part) => part.type)).toEqual(['tool-call'])
-    expect(parts[0]).toMatchObject({
-      type: 'tool-call',
-      toolCallId: 'tool-1',
-      toolName: 'search',
-      input: '{"query":"what does <think>reasoning</think> mean?"}',
-    })
-  })
-
-  test('treats split thinking markers inside tool-call payload as opaque text', () => {
-    const parts = runParser([
-      { token: '<tool_call>' },
-      { token: '{"query":"what does <thi' },
-      { token: 'nk>reasoning</thi' },
-      {
-        token: 'nk> mean?"}',
-        tool_calls: [
-          {
-            id: 'tool-1',
-            type: 'function',
-            function: {
-              name: 'search',
-              arguments: '{"query":"what does <think>reasoning</think> mean?"}',
-            },
-          },
-        ],
-      },
-      { token: '</tool_call>' },
-    ])
-
-    expect(parts.map((part) => part.type)).toEqual(['tool-call'])
-    expect(parts[0]).toMatchObject({
-      type: 'tool-call',
-      toolCallId: 'tool-1',
-      toolName: 'search',
-      input: '{"query":"what does <think>reasoning</think> mean?"}',
     })
   })
 })

--- a/packages/llama/src/ai-sdk.ts
+++ b/packages/llama/src/ai-sdk.ts
@@ -6,7 +6,6 @@ import type {
   LanguageModelV3CallOptions,
   LanguageModelV3Content,
   LanguageModelV3FinishReason,
-  LanguageModelV3Prompt,
   LanguageModelV3StreamPart,
   RerankingModelV3,
   RerankingModelV3CallOptions,
@@ -15,7 +14,6 @@ import type {
 } from '@ai-sdk/provider'
 import { generateId } from '@ai-sdk/provider-utils'
 import {
-  type CompletionParams,
   type ContextParams,
   type EmbeddingParams,
   initLlama,
@@ -24,25 +22,11 @@ import {
   type NativeEmbeddingResult,
 } from 'llama.rn'
 
+import {
+  buildLlamaCompletionOptions,
+  prepareMessagesWithMedia,
+} from './completionOptions'
 import { createLlamaStreamParser } from './streamParser'
-
-interface LLMMessagePart {
-  type: 'text' | 'image_url' | 'input_audio'
-  text?: string
-  image_url?: { url: string }
-  input_audio?:
-    | { format: string; data: string }
-    | { format: string; url: string }
-}
-
-// Taken from https://github.com/mybigday/llama.rn/blob/main/example/src/utils/llmMessages.ts
-interface LLMMessage {
-  role: 'system' | 'user' | 'assistant' | 'tool'
-  content: string | LLMMessagePart[]
-  reasoning_content?: string
-  tool_call_id?: string
-  tool_calls?: any[]
-}
 
 function convertFinishReason(
   result: NativeCompletionResult
@@ -65,162 +49,6 @@ function convertFinishReason(
     unified,
     raw,
   }
-}
-
-/**
- * Convert Uint8Array to base64 string
- */
-function uint8ArrayToBase64(bytes: Uint8Array): string {
-  let binary = ''
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i])
-  }
-  return btoa(binary)
-}
-
-/**
- * Prepare messages with multimodal support for llama.rn
- *
- * Supports:
- * - Images: JPEG, PNG, BMP, GIF, TGA, HDR, PIC, PNM
- * - Audio: WAV, MP3
- * - Base64 data URLs and local file paths (file:///)
- * - Note: HTTP URLs are not yet supported
- *
- * @see https://github.com/mybigday/llama.rn#multimodal-vision--audio
- */
-function prepareMessagesWithMedia(prompt: LanguageModelV3Prompt): LLMMessage[] {
-  const messages: LLMMessage[] = []
-
-  type PromptPart = Extract<
-    LanguageModelV3Prompt[number],
-    { content: unknown[] }
-  >['content'][number]
-
-  const convertFilePartToMedia = (
-    part: Extract<PromptPart, { type: 'file' }>
-  ): LLMMessagePart => {
-    const mediaType = part.mediaType.toLowerCase()
-    const data = part.data as unknown
-
-    const url =
-      data instanceof Uint8Array
-        ? `data:${part.mediaType};base64,${uint8ArrayToBase64(data)}`
-        : data instanceof URL
-          ? data.toString()
-          : typeof data === 'string'
-            ? data
-            : null
-
-    if (!url) {
-      return { type: 'text', text: '' }
-    }
-
-    if (mediaType.startsWith('image/')) {
-      return { type: 'image_url', image_url: { url } }
-    }
-
-    if (mediaType.startsWith('audio/')) {
-      const format = mediaType.includes('wav') ? 'wav' : 'mp3'
-      if (url.startsWith('data:')) {
-        return {
-          type: 'input_audio',
-          input_audio: {
-            format,
-            data: url,
-          },
-        }
-      }
-      return {
-        type: 'input_audio',
-        input_audio: {
-          format,
-          url,
-        },
-      }
-    }
-
-    return { type: 'text', text: '' }
-  }
-
-  for (const message of prompt) {
-    switch (message.role) {
-      case 'system':
-      case 'user':
-        if (typeof message.content === 'string') {
-          messages.push({ role: message.role, content: message.content })
-        } else {
-          for (const part of message.content) {
-            switch (part.type) {
-              case 'text':
-                messages.push({ role: message.role, content: part.text })
-                break
-              case 'file':
-                messages.push({
-                  role: message.role,
-                  content: [convertFilePartToMedia(part)],
-                })
-                break
-              default:
-                throw new Error(
-                  `Unsupported message content type: ${JSON.stringify(part)}`
-                )
-            }
-          }
-        }
-        break
-      case 'assistant': {
-        const reasoningContent = message.content.find(
-          (part) => part.type === 'reasoning'
-        )
-        const toolCalls = message.content.filter(
-          (part) => part.type === 'tool-call'
-        )
-        const content = message.content.filter((part) => part.type === 'text')
-        messages.push({
-          role: 'assistant',
-          content,
-          reasoning_content: reasoningContent?.text,
-          tool_calls: toolCalls.map((toolCall) => ({
-            type: 'function',
-            id: toolCall.toolCallId,
-            function: {
-              name: toolCall.toolName,
-              arguments: JSON.stringify(toolCall.input),
-            },
-          })),
-        })
-        const toolResults = message.content.filter(
-          (part) => part.type === 'tool-result'
-        )
-        if (toolResults.length > 0) {
-          console.warn(
-            '[llama] Model executed tools are not supported. Skipping:',
-            toolResults
-          )
-        }
-        break
-      }
-      case 'tool': {
-        const toolResults = message.content.filter(
-          (part) => part.type === 'tool-result'
-        )
-        for (const toolResult of toolResults) {
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolResult.toolCallId,
-            content:
-              toolResult.output.type === 'execution-denied'
-                ? (toolResult.output.reason ?? 'Execution denied')
-                : JSON.stringify(toolResult.output.value),
-          })
-        }
-        break
-      }
-    }
-  }
-
-  return messages
 }
 
 /**
@@ -379,33 +207,7 @@ export class LlamaLanguageModel implements LanguageModelV3 {
 
     const messages = prepareMessagesWithMedia(options.prompt)
 
-    const completionOptions: Partial<CompletionParams> = {
-      messages,
-      temperature: options.temperature,
-      n_predict: options.maxOutputTokens,
-      top_p: options.topP,
-      top_k: options.topK,
-      penalty_present: options.presencePenalty,
-      penalty_freq: options.frequencyPenalty,
-      stop: options.stopSequences,
-      seed: options.seed,
-      reasoning_format: 'auto',
-    }
-
-    if (options.responseFormat?.type === 'json') {
-      completionOptions.response_format = {
-        type: 'json_object',
-        schema: options.responseFormat.schema,
-      }
-    }
-
-    if (options.tools) {
-      completionOptions.tools = options.tools.map(({ type, ...tool }) => ({
-        type,
-        function: tool,
-      }))
-      completionOptions.tool_choice = options.toolChoice?.type ?? 'auto'
-    }
+    const completionOptions = buildLlamaCompletionOptions(options, messages)
 
     const response = await context.completion(completionOptions)
     let content: LanguageModelV3Content[] = []
@@ -483,32 +285,7 @@ export class LlamaLanguageModel implements LanguageModelV3 {
 
     const messages = prepareMessagesWithMedia(options.prompt)
 
-    const completionOptions: Partial<CompletionParams> = {
-      messages,
-      temperature: options.temperature,
-      n_predict: options.maxOutputTokens,
-      top_p: options.topP,
-      top_k: options.topK,
-      penalty_present: options.presencePenalty,
-      penalty_freq: options.frequencyPenalty,
-      stop: options.stopSequences,
-      seed: options.seed,
-    }
-
-    if (options.tools) {
-      completionOptions.tools = options.tools.map(({ type, ...tool }) => ({
-        type,
-        function: tool,
-      }))
-      completionOptions.tool_choice = options.toolChoice?.type ?? 'auto'
-    }
-
-    if (options.responseFormat?.type === 'json') {
-      completionOptions.response_format = {
-        type: 'json_object',
-        schema: options.responseFormat.schema,
-      }
-    }
+    const completionOptions = buildLlamaCompletionOptions(options, messages)
 
     const stream = new ReadableStream<LanguageModelV3StreamPart>({
       start: async (controller) => {

--- a/packages/llama/src/completionOptions.ts
+++ b/packages/llama/src/completionOptions.ts
@@ -1,0 +1,202 @@
+import type {
+  LanguageModelV3CallOptions,
+  LanguageModelV3Prompt,
+} from '@ai-sdk/provider'
+import type { CompletionParams } from 'llama.rn'
+
+interface LLMMessagePart {
+  type: 'text' | 'image_url' | 'input_audio'
+  text?: string
+  image_url?: { url: string }
+  input_audio?:
+    | { format: string; data: string }
+    | { format: string; url: string }
+}
+
+interface LLMMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content: string | LLMMessagePart[]
+  reasoning_content?: string
+  tool_call_id?: string
+  tool_calls?: any[]
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+export function prepareMessagesWithMedia(
+  prompt: LanguageModelV3Prompt
+): LLMMessage[] {
+  const messages: LLMMessage[] = []
+
+  type PromptPart = Extract<
+    LanguageModelV3Prompt[number],
+    { content: unknown[] }
+  >['content'][number]
+
+  const convertFilePartToMedia = (
+    part: Extract<PromptPart, { type: 'file' }>
+  ): LLMMessagePart => {
+    const mediaType = part.mediaType.toLowerCase()
+    const data = part.data as unknown
+
+    const url =
+      data instanceof Uint8Array
+        ? `data:${part.mediaType};base64,${uint8ArrayToBase64(data)}`
+        : data instanceof URL
+          ? data.toString()
+          : typeof data === 'string'
+            ? data
+            : null
+
+    if (!url) {
+      return { type: 'text', text: '' }
+    }
+
+    if (mediaType.startsWith('image/')) {
+      return { type: 'image_url', image_url: { url } }
+    }
+
+    if (mediaType.startsWith('audio/')) {
+      const format = mediaType.includes('wav') ? 'wav' : 'mp3'
+      if (url.startsWith('data:')) {
+        return {
+          type: 'input_audio',
+          input_audio: {
+            format,
+            data: url,
+          },
+        }
+      }
+      return {
+        type: 'input_audio',
+        input_audio: {
+          format,
+          url,
+        },
+      }
+    }
+
+    return { type: 'text', text: '' }
+  }
+
+  for (const message of prompt) {
+    switch (message.role) {
+      case 'system':
+      case 'user':
+        if (typeof message.content === 'string') {
+          messages.push({ role: message.role, content: message.content })
+        } else {
+          for (const part of message.content) {
+            switch (part.type) {
+              case 'text':
+                messages.push({ role: message.role, content: part.text })
+                break
+              case 'file':
+                messages.push({
+                  role: message.role,
+                  content: [convertFilePartToMedia(part)],
+                })
+                break
+              default:
+                throw new Error(
+                  `Unsupported message content type: ${JSON.stringify(part)}`
+                )
+            }
+          }
+        }
+        break
+      case 'assistant': {
+        const reasoningContent = message.content.find(
+          (part) => part.type === 'reasoning'
+        )
+        const toolCalls = message.content.filter(
+          (part) => part.type === 'tool-call'
+        )
+        const content = message.content.filter((part) => part.type === 'text')
+        messages.push({
+          role: 'assistant',
+          content,
+          reasoning_content: reasoningContent?.text,
+          tool_calls: toolCalls.map((toolCall) => ({
+            type: 'function',
+            id: toolCall.toolCallId,
+            function: {
+              name: toolCall.toolName,
+              arguments: JSON.stringify(toolCall.input),
+            },
+          })),
+        })
+        const toolResults = message.content.filter(
+          (part) => part.type === 'tool-result'
+        )
+        if (toolResults.length > 0) {
+          console.warn(
+            '[llama] Model executed tools are not supported. Skipping:',
+            toolResults
+          )
+        }
+        break
+      }
+      case 'tool': {
+        const toolResults = message.content.filter(
+          (part) => part.type === 'tool-result'
+        )
+        for (const toolResult of toolResults) {
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolResult.toolCallId,
+            content:
+              toolResult.output.type === 'execution-denied'
+                ? (toolResult.output.reason ?? 'Execution denied')
+                : JSON.stringify(toolResult.output.value),
+          })
+        }
+        break
+      }
+    }
+  }
+
+  return messages
+}
+
+export function buildLlamaCompletionOptions(
+  options: LanguageModelV3CallOptions,
+  messages: LLMMessage[]
+): Partial<CompletionParams> {
+  const completionOptions: Partial<CompletionParams> = {
+    messages,
+    temperature: options.temperature,
+    n_predict: options.maxOutputTokens,
+    top_p: options.topP,
+    top_k: options.topK,
+    penalty_present: options.presencePenalty,
+    penalty_freq: options.frequencyPenalty,
+    stop: options.stopSequences,
+    seed: options.seed,
+    reasoning_format: 'auto',
+    ...(options.providerOptions?.llama ?? {}),
+  }
+
+  if (options.tools) {
+    completionOptions.tools = options.tools.map(({ type, ...tool }) => ({
+      type,
+      function: tool,
+    }))
+    completionOptions.tool_choice = options.toolChoice?.type ?? 'auto'
+  }
+
+  if (options.responseFormat?.type === 'json') {
+    completionOptions.response_format = {
+      type: 'json_object',
+      schema: options.responseFormat.schema,
+    }
+  }
+
+  return completionOptions
+}

--- a/packages/llama/src/index.ts
+++ b/packages/llama/src/index.ts
@@ -12,6 +12,10 @@ export {
   LlamaRerankModel,
   LlamaSpeechModel,
 } from './ai-sdk'
+export {
+  buildLlamaCompletionOptions,
+  prepareMessagesWithMedia,
+} from './completionOptions'
 export type {
   CompletionParams,
   ContextParams,

--- a/packages/llama/src/streamParser.ts
+++ b/packages/llama/src/streamParser.ts
@@ -82,6 +82,8 @@ export function createLlamaStreamParser(
   let pendingText = ''
   let pendingToolCallIds = new Set<string>()
   let pendingToolCalls: NonNullable<TokenData['tool_calls']> = []
+  let lastNativeContent = ''
+  let lastNativeReasoning = ''
 
   const finishCurrentBlock = () => {
     if (state === 'text') {
@@ -133,6 +135,26 @@ export function createLlamaStreamParser(
     })
   }
 
+  const openReasoningBlock = () => {
+    finishCurrentBlock()
+    state = 'reasoning'
+    currentChunkId = generateId()
+    sink.enqueue({
+      type: 'reasoning-start',
+      id: currentChunkId,
+    })
+  }
+
+  const openTextBlock = () => {
+    finishCurrentBlock()
+    state = 'text'
+    currentChunkId = generateId()
+    sink.enqueue({
+      type: 'text-start',
+      id: currentChunkId,
+    })
+  }
+
   const queueToolCalls = (toolCalls: TokenData['tool_calls']) => {
     for (const toolCall of toolCalls ?? []) {
       if (!toolCall.id) {
@@ -162,15 +184,87 @@ export function createLlamaStreamParser(
     pendingToolCalls = []
   }
 
+  const emitNativeDelta = (type: 'text' | 'reasoning', value: string) => {
+    const previousValue =
+      type === 'text' ? lastNativeContent : lastNativeReasoning
+
+    if (
+      value.length < previousValue.length ||
+      !value.startsWith(previousValue)
+    ) {
+      if (type === 'text') {
+        openTextBlock()
+      } else {
+        openReasoningBlock()
+      }
+
+      const resetDelta = value
+      if (type === 'text') {
+        lastNativeContent = value
+      } else {
+        lastNativeReasoning = value
+      }
+      emitDelta(resetDelta)
+      return
+    }
+
+    const delta = value.slice(previousValue.length)
+    if (!delta) {
+      if (type === 'text') {
+        lastNativeContent = value
+      } else {
+        lastNativeReasoning = value
+      }
+      return
+    }
+
+    if (type === 'text' && state !== 'text') {
+      openTextBlock()
+    }
+
+    if (type === 'reasoning' && state !== 'reasoning') {
+      openReasoningBlock()
+    }
+
+    if (type === 'text') {
+      lastNativeContent = value
+    } else {
+      lastNativeReasoning = value
+    }
+
+    emitDelta(delta)
+  }
+
+  const processNativeParsedContent = (tokenData: TokenData) => {
+    const reasoningValue = tokenData.reasoning_content ?? ''
+    const contentValue = tokenData.content ?? ''
+
+    if (!reasoningValue && lastNativeReasoning) {
+      lastNativeReasoning = ''
+      if (state === 'reasoning') {
+        finishCurrentBlock()
+      }
+    }
+
+    if (reasoningValue) {
+      emitNativeDelta('reasoning', reasoningValue)
+    }
+
+    if (!contentValue && lastNativeContent) {
+      lastNativeContent = ''
+      if (state === 'text') {
+        finishCurrentBlock()
+      }
+    }
+
+    if (contentValue) {
+      emitNativeDelta('text', contentValue)
+    }
+  }
+
   const handlePlaceholder = (placeholder: Placeholder) => {
     if (placeholder === START_OF_THINKING_PLACEHOLDER) {
-      finishCurrentBlock()
-      state = 'reasoning'
-      currentChunkId = generateId()
-      sink.enqueue({
-        type: 'reasoning-start',
-        id: currentChunkId,
-      })
+      openReasoningBlock()
       return
     }
 
@@ -231,6 +325,15 @@ export function createLlamaStreamParser(
       queueToolCalls(tokenData.tool_calls)
     }
 
+    const hasNativeParsedContent =
+      tokenData.content !== undefined ||
+      tokenData.reasoning_content !== undefined
+
+    if (hasNativeParsedContent) {
+      processNativeParsedContent(tokenData)
+      return
+    }
+
     pendingText += tokenData.token
     flushBuffer(false)
   }
@@ -239,10 +342,9 @@ export function createLlamaStreamParser(
     processToken,
     finish: () => {
       flushBuffer(true)
-      if (state === 'tool-call') {
+      if (pendingToolCalls.length > 0) {
         finishCurrentBlock()
         emitPendingToolCalls()
-        return
       }
       finishCurrentBlock()
     },

--- a/packages/llama/src/streamParser.ts
+++ b/packages/llama/src/streamParser.ts
@@ -330,6 +330,13 @@ export function createLlamaStreamParser(
       tokenData.reasoning_content !== undefined
 
     if (hasNativeParsedContent) {
+      if (
+        pendingToolCalls.length > 0 &&
+        tokenData.token.includes(END_OF_TOOL_CALL_PLACEHOLDER)
+      ) {
+        finishCurrentBlock()
+        emitPendingToolCalls()
+      }
       processNativeParsedContent(tokenData)
       return
     }


### PR DESCRIPTION
Related issue - [#199](https://github.com/callstackincubator/ai/issues/199)

## Summary
Improves the `@react-native-ai/llama` streaming adapter by preferring native parsed reasoning/content fields from `llama.rn` when they are available, instead of relying only on placeholder parsing of raw token text.
Previously, the adapter inferred reasoning boundaries entirely from streamed token markers like `<think>...</think>`. That fallback parser remains useful, but newer `llama.rn` versions can expose native structured fields such as `tokenData.reasoning_content` and `tokenData.content`, which are a more reliable source of truth.
This change updates the stream parser to use native parsed fields when present, emit proper incremental deltas from their accumulated values, preserve fallback placeholder parsing when native fields are absent, and keep tool-call behavior intact across both paths.

## Changes
- Prefer native `tokenData.reasoning_content` for reasoning stream output when available
- Prefer native `tokenData.content` for normal text stream output when available
- Track previously emitted native values and emit only new suffixes as deltas
- Preserve fallback placeholder parsing when native fields are absent
- Prevent duplicate text/reasoning emission when native fields and raw token text coexist on the same chunk
- Ensure buffered fallback text is still flushed safely after native chunks
- Preserve queued tool-call emission even when native parsed fields are present on a chunk
- Keep `<think>` markers inside tool-call payload text untouched
- Keep split `<think>` markers inside tool-call payload text untouched
- Extract llama completion option building into `buildLlamaCompletionOptions`
- Add focused unit tests for `providerOptions.llama` passthrough
- Export the completion-options helper from the llama package entrypoint

## Testing
- Ran `bun test packages/llama/src/__tests__/streamParser.test.ts`
- Ran `bun test packages/llama/src/__tests__/completionOptions.test.ts`
- Ran `./node_modules/.bin/tsc --noEmit --project packages/llama/tsconfig.json`
- Ran `./node_modules/.bin/tsc --noEmit --project packages/llama/tsconfig.build.json`
- Ran `bun lint`
- Added regression coverage for:
  - native reasoning/content delta emission from accumulated values
  - native chunks that also include raw token text
  - fallback placeholder parsing when native fields are absent
  - buffered fallback flushing after native chunks
  - tool-call payloads containing `<think>` markers
  - split `<think>` markers inside tool-call payloads
  - queued tool-call emission from native chunks