### PR TITLE
feat: WWDC26 Apple Intelligence APIs

### DIFF
--- a/apps/expo-example/app.json
+++ b/apps/expo-example/app.json
@@ -39,6 +39,7 @@
         "expo-build-properties",
         {
           "ios": {
+            "deploymentTarget": "15.1",
             "extraPods": [
               {
                 "name": "SDWebImage",

--- a/apps/expo-example/package.json
+++ b/apps/expo-example/package.json
@@ -20,6 +20,7 @@
     "@react-native-ai/json-ui": "workspace:*",
     "@react-native-ai/llama": "workspace:*",
     "@react-native-ai/mlc": "workspace:*",
+    "@react-native-ai/utils": "workspace:*",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-picker/picker": "2.11.1",
     "@react-navigation/bottom-tabs": "^7.9.0",

--- a/apps/expo-example/src/screens/ChatScreen/ChatMessages.tsx
+++ b/apps/expo-example/src/screens/ChatScreen/ChatMessages.tsx
@@ -29,6 +29,7 @@ type ChatMessage = {
 type ChatMessagesProps = {
   messages: ChatMessage[]
   selectedModelLabel: string
+  emptyStateSubtitle: string
   onSend: (message: string) => void
   isGenerating: boolean
   genUiEnabled: boolean
@@ -38,6 +39,7 @@ type ChatMessagesProps = {
 export function ChatMessages({
   messages,
   selectedModelLabel,
+  emptyStateSubtitle,
   onSend,
   isGenerating,
   genUiEnabled,
@@ -86,11 +88,7 @@ export function ChatMessages({
         {messages.length === 0 ? (
           <ChatEmptyState
             title="What can I help you with?"
-            subtitle={
-              genUiEnabled
-                ? `Start a conversation with ${selectedModelLabel}. Ask questions, ask it to add new UI elements to the screen, get creative, or explore ideas.`
-                : `Start a conversation with ${selectedModelLabel}. Ask questions, get creative, or explore ideas.`
-            }
+            subtitle={emptyStateSubtitle}
           />
         ) : (
           <View style={styles.messageList}>

--- a/apps/expo-example/src/screens/ChatScreen/SettingsSheet.tsx
+++ b/apps/expo-example/src/screens/ChatScreen/SettingsSheet.tsx
@@ -23,15 +23,7 @@ type SettingsSheetProps = {
 
 export function SettingsSheet({ ref }: SettingsSheetProps) {
   const { chatSettings, toggleTool, updateChatSettings } = useChatStore()
-  const {
-    temperature,
-    maxSteps,
-    enabledToolIds,
-    genUiEnabled,
-    appleHistoryDemoEnabled,
-    appleHistoryWindowEntries,
-    appleHistorySummarizationThreshold,
-  } = chatSettings
+  const { temperature, maxSteps, enabledToolIds, genUiEnabled } = chatSettings
 
   return (
     <TrueSheet ref={ref} scrollable style={styles.sheetContainerSlidingWrapper}>
@@ -106,21 +98,6 @@ export function SettingsSheet({ ref }: SettingsSheetProps) {
                   }
                 />
               </View>
-              <View style={styles.settingRowToggleWithBorder}>
-                <View style={styles.settingToggleText}>
-                  <Text style={styles.settingTitle}>Apple History Demo</Text>
-                  <Text style={styles.settingDescription}>
-                    Exercise summarizeHistory, rollingWindow, and
-                    droppingCompletedToolCalls in chat
-                  </Text>
-                </View>
-                <Switch
-                  value={appleHistoryDemoEnabled}
-                  onValueChange={(value) =>
-                    updateChatSettings({ appleHistoryDemoEnabled: value })
-                  }
-                />
-              </View>
             </View>
           </View>
 
@@ -174,68 +151,10 @@ export function SettingsSheet({ ref }: SettingsSheetProps) {
                   />
                 </Host>
               </View>
-              {appleHistoryDemoEnabled && (
-                <>
-                  <View style={styles.settingRowSliderWithBorder}>
-                    <View style={styles.settingSliderHeader}>
-                      <Text style={styles.settingTitle}>History Window</Text>
-                      <Text style={styles.settingValue}>
-                        {appleHistoryWindowEntries}
-                      </Text>
-                    </View>
-                    <Host style={styles.sliderHost}>
-                      <Slider
-                        value={appleHistoryWindowEntries}
-                        min={2}
-                        max={20}
-                        steps={18}
-                        onValueChange={(value) =>
-                          updateChatSettings({
-                            appleHistoryWindowEntries: Math.round(value),
-                          })
-                        }
-                        style={
-                          Platform.OS === 'android'
-                            ? styles.androidSlider
-                            : undefined
-                        }
-                      />
-                    </Host>
-                  </View>
-                  <View style={styles.settingRowSliderWithBorder}>
-                    <View style={styles.settingSliderHeader}>
-                      <Text style={styles.settingTitle}>Summary Threshold</Text>
-                      <Text style={styles.settingValue}>
-                        {appleHistorySummarizationThreshold}
-                      </Text>
-                    </View>
-                    <Host style={styles.sliderHost}>
-                      <Slider
-                        value={appleHistorySummarizationThreshold}
-                        min={500}
-                        max={8000}
-                        steps={150}
-                        onValueChange={(value) =>
-                          updateChatSettings({
-                            appleHistorySummarizationThreshold:
-                              Math.round(value),
-                          })
-                        }
-                        style={
-                          Platform.OS === 'android'
-                            ? styles.androidSlider
-                            : undefined
-                        }
-                      />
-                    </Host>
-                  </View>
-                </>
-              )}
             </View>
             <Text style={styles.settingsFooter}>
-              {appleHistoryDemoEnabled
-                ? 'Temperature controls response randomness. Max steps limits tool call iterations. Apple History Demo applies the new history wrappers on top of the current basic chat flow. Summary Threshold uses tokens when available and otherwise falls back to an estimate.'
-                : 'Temperature controls response randomness. Max steps limits tool call iterations.'}
+              Temperature controls response randomness. Max steps limits tool
+              call iterations.
             </Text>
           </View>
         </ScrollView>
@@ -331,15 +250,6 @@ const styles = StyleSheet.create({
     gap: 12,
     paddingHorizontal: 16,
     paddingVertical: 12,
-  },
-  settingRowToggleWithBorder: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: colors.separator as any,
   },
   settingToggleText: {
     flex: 1,

--- a/apps/expo-example/src/screens/ChatScreen/SettingsSheet.tsx
+++ b/apps/expo-example/src/screens/ChatScreen/SettingsSheet.tsx
@@ -23,7 +23,15 @@ type SettingsSheetProps = {
 
 export function SettingsSheet({ ref }: SettingsSheetProps) {
   const { chatSettings, toggleTool, updateChatSettings } = useChatStore()
-  const { temperature, maxSteps, enabledToolIds, genUiEnabled } = chatSettings
+  const {
+    temperature,
+    maxSteps,
+    enabledToolIds,
+    genUiEnabled,
+    appleHistoryDemoEnabled,
+    appleHistoryWindowEntries,
+    appleHistorySummarizationThreshold,
+  } = chatSettings
 
   return (
     <TrueSheet ref={ref} scrollable style={styles.sheetContainerSlidingWrapper}>
@@ -98,6 +106,21 @@ export function SettingsSheet({ ref }: SettingsSheetProps) {
                   }
                 />
               </View>
+              <View style={styles.settingRowToggleWithBorder}>
+                <View style={styles.settingToggleText}>
+                  <Text style={styles.settingTitle}>Apple History Demo</Text>
+                  <Text style={styles.settingDescription}>
+                    Exercise summarizeHistory, rollingWindow, and
+                    droppingCompletedToolCalls in chat
+                  </Text>
+                </View>
+                <Switch
+                  value={appleHistoryDemoEnabled}
+                  onValueChange={(value) =>
+                    updateChatSettings({ appleHistoryDemoEnabled: value })
+                  }
+                />
+              </View>
             </View>
           </View>
 
@@ -151,10 +174,68 @@ export function SettingsSheet({ ref }: SettingsSheetProps) {
                   />
                 </Host>
               </View>
+              {appleHistoryDemoEnabled && (
+                <>
+                  <View style={styles.settingRowSliderWithBorder}>
+                    <View style={styles.settingSliderHeader}>
+                      <Text style={styles.settingTitle}>History Window</Text>
+                      <Text style={styles.settingValue}>
+                        {appleHistoryWindowEntries}
+                      </Text>
+                    </View>
+                    <Host style={styles.sliderHost}>
+                      <Slider
+                        value={appleHistoryWindowEntries}
+                        min={2}
+                        max={20}
+                        steps={18}
+                        onValueChange={(value) =>
+                          updateChatSettings({
+                            appleHistoryWindowEntries: Math.round(value),
+                          })
+                        }
+                        style={
+                          Platform.OS === 'android'
+                            ? styles.androidSlider
+                            : undefined
+                        }
+                      />
+                    </Host>
+                  </View>
+                  <View style={styles.settingRowSliderWithBorder}>
+                    <View style={styles.settingSliderHeader}>
+                      <Text style={styles.settingTitle}>Summary Threshold</Text>
+                      <Text style={styles.settingValue}>
+                        {appleHistorySummarizationThreshold}
+                      </Text>
+                    </View>
+                    <Host style={styles.sliderHost}>
+                      <Slider
+                        value={appleHistorySummarizationThreshold}
+                        min={500}
+                        max={8000}
+                        steps={150}
+                        onValueChange={(value) =>
+                          updateChatSettings({
+                            appleHistorySummarizationThreshold:
+                              Math.round(value),
+                          })
+                        }
+                        style={
+                          Platform.OS === 'android'
+                            ? styles.androidSlider
+                            : undefined
+                        }
+                      />
+                    </Host>
+                  </View>
+                </>
+              )}
             </View>
             <Text style={styles.settingsFooter}>
-              Temperature controls response randomness. Max steps limits tool
-              call iterations.
+              {appleHistoryDemoEnabled
+                ? 'Temperature controls response randomness. Max steps limits tool call iterations. Apple History Demo applies the new history wrappers on top of the current basic chat flow. Summary Threshold uses tokens when available and otherwise falls back to an estimate.'
+                : 'Temperature controls response randomness. Max steps limits tool call iterations.'}
             </Text>
           </View>
         </ScrollView>
@@ -250,6 +331,15 @@ const styles = StyleSheet.create({
     gap: 12,
     paddingHorizontal: 16,
     paddingVertical: 12,
+  },
+  settingRowToggleWithBorder: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.separator as any,
   },
   settingToggleText: {
     flex: 1,

--- a/apps/expo-example/src/screens/ChatScreen/SettingsSheet.tsx
+++ b/apps/expo-example/src/screens/ChatScreen/SettingsSheet.tsx
@@ -23,7 +23,15 @@ type SettingsSheetProps = {
 
 export function SettingsSheet({ ref }: SettingsSheetProps) {
   const { chatSettings, toggleTool, updateChatSettings } = useChatStore()
-  const { temperature, maxSteps, enabledToolIds, genUiEnabled } = chatSettings
+  const {
+    temperature,
+    maxSteps,
+    enabledToolIds,
+    genUiEnabled,
+    historyDemoEnabled,
+    historyWindowEntries,
+    historySummarizationThreshold,
+  } = chatSettings
 
   return (
     <TrueSheet ref={ref} scrollable style={styles.sheetContainerSlidingWrapper}>
@@ -98,6 +106,21 @@ export function SettingsSheet({ ref }: SettingsSheetProps) {
                   }
                 />
               </View>
+              <View style={styles.settingRowToggleWithBorder}>
+                <View style={styles.settingToggleText}>
+                  <Text style={styles.settingTitle}>History Demo</Text>
+                  <Text style={styles.settingDescription}>
+                    Exercise summarizeHistory, rollingWindow, and
+                    droppingCompletedToolCalls in chat
+                  </Text>
+                </View>
+                <Switch
+                  value={historyDemoEnabled}
+                  onValueChange={(value) =>
+                    updateChatSettings({ historyDemoEnabled: value })
+                  }
+                />
+              </View>
             </View>
           </View>
 
@@ -151,10 +174,67 @@ export function SettingsSheet({ ref }: SettingsSheetProps) {
                   />
                 </Host>
               </View>
+              {historyDemoEnabled && (
+                <>
+                  <View style={styles.settingRowSliderWithBorder}>
+                    <View style={styles.settingSliderHeader}>
+                      <Text style={styles.settingTitle}>History Window</Text>
+                      <Text style={styles.settingValue}>
+                        {historyWindowEntries}
+                      </Text>
+                    </View>
+                    <Host style={styles.sliderHost}>
+                      <Slider
+                        value={historyWindowEntries}
+                        min={2}
+                        max={20}
+                        steps={18}
+                        onValueChange={(value) =>
+                          updateChatSettings({
+                            historyWindowEntries: Math.round(value),
+                          })
+                        }
+                        style={
+                          Platform.OS === 'android'
+                            ? styles.androidSlider
+                            : undefined
+                        }
+                      />
+                    </Host>
+                  </View>
+                  <View style={styles.settingRowSliderWithBorder}>
+                    <View style={styles.settingSliderHeader}>
+                      <Text style={styles.settingTitle}>Summary Threshold</Text>
+                      <Text style={styles.settingValue}>
+                        {historySummarizationThreshold}
+                      </Text>
+                    </View>
+                    <Host style={styles.sliderHost}>
+                      <Slider
+                        value={historySummarizationThreshold}
+                        min={500}
+                        max={8000}
+                        steps={150}
+                        onValueChange={(value) =>
+                          updateChatSettings({
+                            historySummarizationThreshold: Math.round(value),
+                          })
+                        }
+                        style={
+                          Platform.OS === 'android'
+                            ? styles.androidSlider
+                            : undefined
+                        }
+                      />
+                    </Host>
+                  </View>
+                </>
+              )}
             </View>
             <Text style={styles.settingsFooter}>
-              Temperature controls response randomness. Max steps limits tool
-              call iterations.
+              {historyDemoEnabled
+                ? 'Temperature controls response randomness. Max steps limits tool call iterations. History Demo applies generic history wrappers on top of the current basic chat flow. Summary Threshold uses tokens when available and otherwise falls back to an estimate.'
+                : 'Temperature controls response randomness. Max steps limits tool call iterations.'}
             </Text>
           </View>
         </ScrollView>
@@ -250,6 +330,15 @@ const styles = StyleSheet.create({
     gap: 12,
     paddingHorizontal: 16,
     paddingVertical: 12,
+  },
+  settingRowToggleWithBorder: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.separator as any,
   },
   settingToggleText: {
     flex: 1,

--- a/apps/expo-example/src/screens/ChatScreen/index.tsx
+++ b/apps/expo-example/src/screens/ChatScreen/index.tsx
@@ -1,5 +1,8 @@
 import type { TrueSheet } from '@lodev09/react-native-true-sheet'
-import type { createAppleProvider } from '@react-native-ai/apple'
+import {
+  type AppleLanguageModel,
+  createAppleProvider,
+} from '@react-native-ai/apple'
 import {
   buildGenUISystemPrompt,
   createGenUITools,
@@ -49,6 +52,9 @@ export default function ChatScreen() {
     maxSteps,
     enabledToolIds,
     genUiEnabled,
+    appleHistoryDemoEnabled,
+    appleHistoryWindowEntries,
+    appleHistorySummarizationThreshold,
   } = chatSettings
 
   const [isGenerating, setIsGenerating] = useState(false)
@@ -97,19 +103,33 @@ export default function ChatScreen() {
         ),
         ...genUITools,
       }
-      if ('updateTools' in selectedAdapter.model) {
-        ;(
-          selectedAdapter.model as ReturnType<
-            ReturnType<typeof createAppleProvider>['languageModel']
-          >
-        ).updateTools(tools)
+      let model = selectedAdapter.model
+      if ('updateTools' in model) {
+        ;(model as AppleLanguageModel).updateTools(tools)
+      }
+
+      if (
+        appleHistoryDemoEnabled &&
+        model.provider === 'apple' &&
+        'rollingWindow' in model &&
+        'summarizeHistory' in model &&
+        'droppingCompletedToolCalls' in model
+      ) {
+        // Use a token-style threshold closer to Apple's summarizeHistory API.
+        model = (model as AppleLanguageModel)
+          .summarizeHistory(
+            appleHistorySummarizationThreshold,
+            createAppleProvider().languageModel()
+          )
+          .rollingWindow(appleHistoryWindowEntries)
+          .droppingCompletedToolCalls()
       }
       setToolExecutionReporter(({ toolName, args, result }) => {
         addToolExecutionMessage(chatId, toolName, args, result)
       })
       let streamError: unknown
       const result = streamText({
-        model: selectedAdapter.model,
+        model,
         messages: [
           ...baseMessages
             .filter((message) => message.type !== 'toolExecution')
@@ -185,6 +205,9 @@ export default function ChatScreen() {
   const showAppleTokenCount =
     selectedAdapter?.model.provider === 'apple' &&
     selectedModelAvailability === 'yes'
+  const emptyStateSubtitle = genUiEnabled
+    ? `Start a conversation with ${headerSubtitle}. Ask questions, ask it to add new UI elements to the screen, get creative, or explore ideas.${appleHistoryDemoEnabled ? ' Apple History Demo is enabled, so this chat also exercises summarizeHistory, rollingWindow, and droppingCompletedToolCalls.' : ''}`
+    : `Start a conversation with ${headerSubtitle}. Ask questions, get creative, or explore ideas.${appleHistoryDemoEnabled ? ' Apple History Demo is enabled, so this chat also exercises summarizeHistory, rollingWindow, and droppingCompletedToolCalls.' : ''}`
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
@@ -204,9 +227,10 @@ export default function ChatScreen() {
         ) : (
           <ChatMessages
             messages={currentChat?.messages ?? []}
+            selectedModelLabel={selectedAdapter.display.label}
+            emptyStateSubtitle={emptyStateSubtitle}
             onSend={handleSend}
             isGenerating={isGenerating}
-            selectedModelLabel={selectedAdapter.display.label}
             genUiEnabled={genUiEnabled}
             showAppleTokenCount={showAppleTokenCount}
           />

--- a/apps/expo-example/src/screens/ChatScreen/index.tsx
+++ b/apps/expo-example/src/screens/ChatScreen/index.tsx
@@ -1,9 +1,5 @@
 import type { TrueSheet } from '@lodev09/react-native-true-sheet'
-import {
-  type AppleLanguageModel,
-  type AppleLanguageModelId,
-  createAppleProvider,
-} from '@react-native-ai/apple'
+import type { AppleLanguageModel } from '@react-native-ai/apple'
 import {
   buildGenUISystemPrompt,
   createGenUITools,
@@ -53,9 +49,6 @@ export default function ChatScreen() {
     maxSteps,
     enabledToolIds,
     genUiEnabled,
-    appleHistoryDemoEnabled,
-    appleHistoryWindowEntries,
-    appleHistorySummarizationThreshold,
   } = chatSettings
 
   const [isGenerating, setIsGenerating] = useState(false)
@@ -104,26 +97,7 @@ export default function ChatScreen() {
         ),
         ...genUITools,
       }
-      let model = selectedAdapter.model
-      if (appleHistoryDemoEnabled && model.provider === 'apple') {
-        const modelId = model.modelId as AppleLanguageModelId
-        const appleProvider = createAppleProvider({
-          availableTools: tools,
-          model: modelId,
-          context: {
-            summarizeHistory: {
-              threshold: appleHistorySummarizationThreshold,
-              model: createAppleProvider({
-                model: modelId,
-              }).languageModel(),
-            },
-            rollingWindowMessages: appleHistoryWindowEntries,
-            dropCompletedToolCalls: true,
-          },
-        })
-        model = appleProvider.languageModel()
-      }
-
+      const model = selectedAdapter.model
       if ('updateTools' in model) {
         ;(model as AppleLanguageModel).updateTools(tools)
       }
@@ -209,8 +183,8 @@ export default function ChatScreen() {
     selectedAdapter?.model.provider === 'apple' &&
     selectedModelAvailability === 'yes'
   const emptyStateSubtitle = genUiEnabled
-    ? `Start a conversation with ${headerSubtitle}. Ask questions, ask it to add new UI elements to the screen, get creative, or explore ideas.${appleHistoryDemoEnabled ? ' Apple History Demo is enabled, so this chat also exercises summarizeHistory, rollingWindow, and droppingCompletedToolCalls.' : ''}`
-    : `Start a conversation with ${headerSubtitle}. Ask questions, get creative, or explore ideas.${appleHistoryDemoEnabled ? ' Apple History Demo is enabled, so this chat also exercises summarizeHistory, rollingWindow, and droppingCompletedToolCalls.' : ''}`
+    ? `Start a conversation with ${headerSubtitle}. Ask questions, ask it to add new UI elements to the screen, get creative, or explore ideas.`
+    : `Start a conversation with ${headerSubtitle}. Ask questions, get creative, or explore ideas.`
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>

--- a/apps/expo-example/src/screens/ChatScreen/index.tsx
+++ b/apps/expo-example/src/screens/ChatScreen/index.tsx
@@ -1,6 +1,7 @@
 import type { TrueSheet } from '@lodev09/react-native-true-sheet'
 import {
   type AppleLanguageModel,
+  type AppleLanguageModelId,
   createAppleProvider,
 } from '@react-native-ai/apple'
 import {
@@ -104,25 +105,27 @@ export default function ChatScreen() {
         ...genUITools,
       }
       let model = selectedAdapter.model
-      if ('updateTools' in model) {
-        ;(model as AppleLanguageModel).updateTools(tools)
+      if (appleHistoryDemoEnabled && model.provider === 'apple') {
+        const modelId = model.modelId as AppleLanguageModelId
+        const appleProvider = createAppleProvider({
+          availableTools: tools,
+          model: modelId,
+          context: {
+            summarizeHistory: {
+              threshold: appleHistorySummarizationThreshold,
+              model: createAppleProvider({
+                model: modelId,
+              }).languageModel(),
+            },
+            rollingWindowMessages: appleHistoryWindowEntries,
+            dropCompletedToolCalls: true,
+          },
+        })
+        model = appleProvider.languageModel()
       }
 
-      if (
-        appleHistoryDemoEnabled &&
-        model.provider === 'apple' &&
-        'rollingWindow' in model &&
-        'summarizeHistory' in model &&
-        'droppingCompletedToolCalls' in model
-      ) {
-        // Use a token-style threshold closer to Apple's summarizeHistory API.
-        model = (model as AppleLanguageModel)
-          .summarizeHistory(
-            appleHistorySummarizationThreshold,
-            createAppleProvider().languageModel()
-          )
-          .rollingWindow(appleHistoryWindowEntries)
-          .droppingCompletedToolCalls()
+      if ('updateTools' in model) {
+        ;(model as AppleLanguageModel).updateTools(tools)
       }
       setToolExecutionReporter(({ toolName, args, result }) => {
         addToolExecutionMessage(chatId, toolName, args, result)

--- a/apps/expo-example/src/screens/ChatScreen/index.tsx
+++ b/apps/expo-example/src/screens/ChatScreen/index.tsx
@@ -4,6 +4,7 @@ import {
   buildGenUISystemPrompt,
   createGenUITools,
 } from '@react-native-ai/json-ui'
+import { wrapLanguageModelWithHistory } from '@react-native-ai/utils'
 import { stepCountIs, streamText } from 'ai'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { StyleSheet, View } from 'react-native'
@@ -49,6 +50,9 @@ export default function ChatScreen() {
     maxSteps,
     enabledToolIds,
     genUiEnabled,
+    historyDemoEnabled,
+    historyWindowEntries,
+    historySummarizationThreshold,
   } = chatSettings
 
   const [isGenerating, setIsGenerating] = useState(false)
@@ -97,9 +101,19 @@ export default function ChatScreen() {
         ),
         ...genUITools,
       }
-      const model = selectedAdapter.model
+      let model = selectedAdapter.model
       if ('updateTools' in model) {
         ;(model as AppleLanguageModel).updateTools(tools)
+      }
+      if (historyDemoEnabled) {
+        model = wrapLanguageModelWithHistory(model, {
+          summarizeHistory: {
+            threshold: historySummarizationThreshold,
+            model,
+          },
+          rollingWindowMessages: historyWindowEntries,
+          dropCompletedToolCalls: true,
+        })
       }
       setToolExecutionReporter(({ toolName, args, result }) => {
         addToolExecutionMessage(chatId, toolName, args, result)
@@ -183,8 +197,8 @@ export default function ChatScreen() {
     selectedAdapter?.model.provider === 'apple' &&
     selectedModelAvailability === 'yes'
   const emptyStateSubtitle = genUiEnabled
-    ? `Start a conversation with ${headerSubtitle}. Ask questions, ask it to add new UI elements to the screen, get creative, or explore ideas.`
-    : `Start a conversation with ${headerSubtitle}. Ask questions, get creative, or explore ideas.`
+    ? `Start a conversation with ${headerSubtitle}. Ask questions, ask it to add new UI elements to the screen, get creative, or explore ideas.${historyDemoEnabled ? ' History Demo is enabled, so this chat also exercises summarizeHistory, rollingWindow, and droppingCompletedToolCalls.' : ''}`
+    : `Start a conversation with ${headerSubtitle}. Ask questions, get creative, or explore ideas.${historyDemoEnabled ? ' History Demo is enabled, so this chat also exercises summarizeHistory, rollingWindow, and droppingCompletedToolCalls.' : ''}`
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>

--- a/apps/expo-example/src/store/chatStore.ts
+++ b/apps/expo-example/src/store/chatStore.ts
@@ -29,6 +29,9 @@ export type ChatSettings = {
   maxSteps: number
   enabledToolIds: string[]
   genUiEnabled: boolean
+  appleHistoryDemoEnabled: boolean
+  appleHistoryWindowEntries: number
+  appleHistorySummarizationThreshold: number
 }
 
 /** Single element in the generative UI tree (id is the key in elements). */
@@ -118,6 +121,9 @@ const DEFAULT_SETTINGS: ChatSettings = {
   maxSteps: 5,
   enabledToolIds: Object.keys(toolDefinitions),
   genUiEnabled: false,
+  appleHistoryDemoEnabled: false,
+  appleHistoryWindowEntries: 10,
+  appleHistorySummarizationThreshold: 5000,
 }
 
 const chatsAtom = atomWithStorage<Chat[]>('chats', [], storage)

--- a/apps/expo-example/src/store/chatStore.ts
+++ b/apps/expo-example/src/store/chatStore.ts
@@ -29,6 +29,9 @@ export type ChatSettings = {
   maxSteps: number
   enabledToolIds: string[]
   genUiEnabled: boolean
+  historyDemoEnabled: boolean
+  historyWindowEntries: number
+  historySummarizationThreshold: number
 }
 
 /** Single element in the generative UI tree (id is the key in elements). */
@@ -118,6 +121,9 @@ const DEFAULT_SETTINGS: ChatSettings = {
   maxSteps: 5,
   enabledToolIds: Object.keys(toolDefinitions),
   genUiEnabled: false,
+  historyDemoEnabled: false,
+  historyWindowEntries: 10,
+  historySummarizationThreshold: 5000,
 }
 
 const chatsAtom = atomWithStorage<Chat[]>('chats', [], storage)

--- a/apps/expo-example/src/store/chatStore.ts
+++ b/apps/expo-example/src/store/chatStore.ts
@@ -29,9 +29,6 @@ export type ChatSettings = {
   maxSteps: number
   enabledToolIds: string[]
   genUiEnabled: boolean
-  appleHistoryDemoEnabled: boolean
-  appleHistoryWindowEntries: number
-  appleHistorySummarizationThreshold: number
 }
 
 /** Single element in the generative UI tree (id is the key in elements). */
@@ -121,9 +118,6 @@ const DEFAULT_SETTINGS: ChatSettings = {
   maxSteps: 5,
   enabledToolIds: Object.keys(toolDefinitions),
   genUiEnabled: false,
-  appleHistoryDemoEnabled: false,
-  appleHistoryWindowEntries: 10,
-  appleHistorySummarizationThreshold: 5000,
 }
 
 const chatsAtom = atomWithStorage<Chat[]>('chats', [], storage)

--- a/apps/expo-example/tsconfig.json
+++ b/apps/expo-example/tsconfig.json
@@ -8,7 +8,8 @@
       "@react-native-ai/mlc": ["../../packages/mlc/src"],
       "@react-native-ai/json-ui": [
         "../../packages/@react-native-ai/json-ui/src"
-      ]
+      ],
+      "@react-native-ai/utils": ["../../packages/utils/src"]
     }
   },
   "include": ["src/**/*", "nativewind-env.d.ts"]

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "@react-native-ai/json-ui": "workspace:*",
         "@react-native-ai/llama": "workspace:*",
         "@react-native-ai/mlc": "workspace:*",
+        "@react-native-ai/utils": "workspace:*",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-picker/picker": "2.11.1",
         "@react-navigation/bottom-tabs": "^7.9.0",
@@ -175,6 +176,13 @@
       "optionalPeers": [
         "expo",
       ],
+    },
+    "packages/utils": {
+      "name": "@react-native-ai/utils",
+      "version": "0.12.0",
+      "dependencies": {
+        "@ai-sdk/provider": "^3.0.5",
+      },
     },
   },
   "packages": {
@@ -765,6 +773,8 @@
     "@react-native-ai/llama": ["@react-native-ai/llama@workspace:packages/llama"],
 
     "@react-native-ai/mlc": ["@react-native-ai/mlc@workspace:packages/mlc"],
+
+    "@react-native-ai/utils": ["@react-native-ai/utils@workspace:packages/utils"],
 
     "@react-native-async-storage/async-storage": ["@react-native-async-storage/async-storage@2.2.0", "", { "dependencies": { "merge-options": "^3.0.4" }, "peerDependencies": { "react-native": "^0.0.0-0 || >=0.65 <1.0" } }, "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -770,29 +770,29 @@
 
     "@react-native-picker/picker": ["@react-native-picker/picker@2.11.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-ThklnkK4fV3yynnIIRBkxxjxR4IFbdMNJVF6tlLdOJ/zEFUEFUEdXY0KmH0iYzMwY8W4/InWsLiA7AkpAbnexA=="],
 
-    "@react-native/assets-registry": ["@react-native/assets-registry@0.81.5", "", {}, "sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w=="],
+    "@react-native/assets-registry": ["@react-native/assets-registry@0.81.4", "", {}, "sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA=="],
 
     "@react-native/babel-plugin-codegen": ["@react-native/babel-plugin-codegen@0.81.4", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@react-native/codegen": "0.81.4" } }, "sha512-6ztXf2Tl2iWznyI/Da/N2Eqymt0Mnn69GCLnEFxFbNdk0HxHPZBNWU9shTXhsLWOL7HATSqwg/bB1+3kY1q+mA=="],
 
     "@react-native/babel-preset": ["@react-native/babel-preset@0.81.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-transform-arrow-functions": "^7.24.7", "@babel/plugin-transform-async-generator-functions": "^7.25.4", "@babel/plugin-transform-async-to-generator": "^7.24.7", "@babel/plugin-transform-block-scoping": "^7.25.0", "@babel/plugin-transform-class-properties": "^7.25.4", "@babel/plugin-transform-classes": "^7.25.4", "@babel/plugin-transform-computed-properties": "^7.24.7", "@babel/plugin-transform-destructuring": "^7.24.8", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-for-of": "^7.24.7", "@babel/plugin-transform-function-name": "^7.25.1", "@babel/plugin-transform-literals": "^7.25.2", "@babel/plugin-transform-logical-assignment-operators": "^7.24.7", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7", "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7", "@babel/plugin-transform-numeric-separator": "^7.24.7", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-optional-catch-binding": "^7.24.7", "@babel/plugin-transform-optional-chaining": "^7.24.8", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-react-display-name": "^7.24.7", "@babel/plugin-transform-react-jsx": "^7.25.2", "@babel/plugin-transform-react-jsx-self": "^7.24.7", "@babel/plugin-transform-react-jsx-source": "^7.24.7", "@babel/plugin-transform-regenerator": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/plugin-transform-shorthand-properties": "^7.24.7", "@babel/plugin-transform-spread": "^7.24.7", "@babel/plugin-transform-sticky-regex": "^7.24.7", "@babel/plugin-transform-typescript": "^7.25.2", "@babel/plugin-transform-unicode-regex": "^7.24.7", "@babel/template": "^7.25.0", "@react-native/babel-plugin-codegen": "0.81.4", "babel-plugin-syntax-hermes-parser": "0.29.1", "babel-plugin-transform-flow-enums": "^0.0.2", "react-refresh": "^0.14.0" } }, "sha512-VYj0c/cTjQJn/RJ5G6P0L9wuYSbU9yGbPYDHCKstlQZQWkk+L9V8ZDbxdJBTIei9Xl3KPQ1odQ4QaeW+4v+AZg=="],
 
-    "@react-native/codegen": ["@react-native/codegen@0.81.5", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g=="],
+    "@react-native/codegen": ["@react-native/codegen@0.81.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw=="],
 
-    "@react-native/community-cli-plugin": ["@react-native/community-cli-plugin@0.81.5", "", { "dependencies": { "@react-native/dev-middleware": "0.81.5", "debug": "^4.4.0", "invariant": "^2.2.4", "metro": "^0.83.1", "metro-config": "^0.83.1", "metro-core": "^0.83.1", "semver": "^7.1.3" }, "peerDependencies": { "@react-native-community/cli": "*", "@react-native/metro-config": "*" }, "optionalPeers": ["@react-native-community/cli", "@react-native/metro-config"] }, "sha512-yWRlmEOtcyvSZ4+OvqPabt+NS36vg0K/WADTQLhrYrm9qdZSuXmq8PmdJWz/68wAqKQ+4KTILiq2kjRQwnyhQw=="],
+    "@react-native/community-cli-plugin": ["@react-native/community-cli-plugin@0.81.4", "", { "dependencies": { "@react-native/dev-middleware": "0.81.4", "debug": "^4.4.0", "invariant": "^2.2.4", "metro": "^0.83.1", "metro-config": "^0.83.1", "metro-core": "^0.83.1", "semver": "^7.1.3" }, "peerDependencies": { "@react-native-community/cli": "*", "@react-native/metro-config": "*" }, "optionalPeers": ["@react-native-community/cli", "@react-native/metro-config"] }, "sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA=="],
 
-    "@react-native/debugger-frontend": ["@react-native/debugger-frontend@0.81.5", "", {}, "sha512-bnd9FSdWKx2ncklOetCgrlwqSGhMHP2zOxObJbOWXoj7GHEmih4MKarBo5/a8gX8EfA1EwRATdfNBQ81DY+h+w=="],
+    "@react-native/debugger-frontend": ["@react-native/debugger-frontend@0.81.4", "", {}, "sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg=="],
 
-    "@react-native/dev-middleware": ["@react-native/dev-middleware@0.81.5", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "@react-native/debugger-frontend": "0.81.5", "chrome-launcher": "^0.15.2", "chromium-edge-launcher": "^0.2.0", "connect": "^3.6.5", "debug": "^4.4.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "open": "^7.0.3", "serve-static": "^1.16.2", "ws": "^6.2.3" } }, "sha512-WfPfZzboYgo/TUtysuD5xyANzzfka8Ebni6RIb2wDxhb56ERi7qDrE4xGhtPsjCL4pQBXSVxyIlCy0d8I6EgGA=="],
+    "@react-native/dev-middleware": ["@react-native/dev-middleware@0.81.4", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "@react-native/debugger-frontend": "0.81.4", "chrome-launcher": "^0.15.2", "chromium-edge-launcher": "^0.2.0", "connect": "^3.6.5", "debug": "^4.4.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "open": "^7.0.3", "serve-static": "^1.16.2", "ws": "^6.2.3" } }, "sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug=="],
 
-    "@react-native/gradle-plugin": ["@react-native/gradle-plugin@0.81.5", "", {}, "sha512-hORRlNBj+ReNMLo9jme3yQ6JQf4GZpVEBLxmTXGGlIL78MAezDZr5/uq9dwElSbcGmLEgeiax6e174Fie6qPLg=="],
+    "@react-native/gradle-plugin": ["@react-native/gradle-plugin@0.81.4", "", {}, "sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw=="],
 
-    "@react-native/js-polyfills": ["@react-native/js-polyfills@0.81.5", "", {}, "sha512-fB7M1CMOCIUudTRuj7kzxIBTVw2KXnsgbQ6+4cbqSxo8NmRRhA0Ul4ZUzZj3rFd3VznTL4Brmocv1oiN0bWZ8w=="],
+    "@react-native/js-polyfills": ["@react-native/js-polyfills@0.81.4", "", {}, "sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w=="],
 
-    "@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
+    "@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.4", "", {}, "sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg=="],
 
     "@react-native/typescript-config": ["@react-native/typescript-config@0.81.4", "", {}, "sha512-1HSrwtfAmtbKHNK2HAMCL5ArbGhxxJjOmTViDQ4nEhLJCAllZjQJyR/Hs1GmwHJokLmgXCcg3VH/13spwQBdxw=="],
 
-    "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.5", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw=="],
+    "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.4", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA=="],
 
     "@react-navigation/bottom-tabs": ["@react-navigation/bottom-tabs@7.9.0", "", { "dependencies": { "@react-navigation/elements": "^2.9.3", "color": "^4.2.3", "sf-symbols-typescript": "^2.1.0" }, "peerDependencies": { "@react-navigation/native": "^7.1.26", "react": ">= 18.2.0", "react-native": "*", "react-native-safe-area-context": ">= 4.0.0", "react-native-screens": ">= 4.0.0" } }, "sha512-024FWdHp3ZsE5rP8tmGI4vh+1z3wg8u8E9Frep8eeGoYo1h9rQhvgofQDGxknmrKsb7t8o8Dim+IZSvl57cPFQ=="],
 
@@ -2036,7 +2036,7 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
-    "metro": ["metro@0.83.3", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.32.0", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.3", "metro-cache": "0.83.3", "metro-cache-key": "0.83.3", "metro-config": "0.83.3", "metro-core": "0.83.3", "metro-file-map": "0.83.3", "metro-resolver": "0.83.3", "metro-runtime": "0.83.3", "metro-source-map": "0.83.3", "metro-symbolicate": "0.83.3", "metro-transform-plugins": "0.83.3", "metro-transform-worker": "0.83.3", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-+rP+/GieOzkt97hSJ0MrPOuAH/jpaS21ZDvL9DJ35QYRDlQcwzcvUlGUf79AnQxq/2NPiS/AULhhM4TKutIt8Q=="],
+    "metro": ["metro@0.83.1", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.29.1", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-config": "0.83.1", "metro-core": "0.83.1", "metro-file-map": "0.83.1", "metro-resolver": "0.83.1", "metro-runtime": "0.83.1", "metro-source-map": "0.83.1", "metro-symbolicate": "0.83.1", "metro-transform-plugins": "0.83.1", "metro-transform-worker": "0.83.1", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA=="],
 
     "metro-babel-transformer": ["metro-babel-transformer@0.83.3", "", { "dependencies": { "@babel/core": "^7.25.2", "flow-enums-runtime": "^0.0.6", "hermes-parser": "0.32.0", "nullthrows": "^1.1.1" } }, "sha512-1vxlvj2yY24ES1O5RsSIvg4a4WeL7PFXgKOHvXTXiW0deLvQr28ExXj6LjwCCDZ4YZLhq6HddLpZnX4dEdSq5g=="],
 
@@ -2044,9 +2044,9 @@
 
     "metro-cache-key": ["metro-cache-key@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-59ZO049jKzSmvBmG/B5bZ6/dztP0ilp0o988nc6dpaDsU05Cl1c/lRf+yx8m9WW/JVgbmfO5MziBU559XjI5Zw=="],
 
-    "metro-config": ["metro-config@0.83.3", "", { "dependencies": { "connect": "^3.6.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.3", "metro-cache": "0.83.3", "metro-core": "0.83.3", "metro-runtime": "0.83.3", "yaml": "^2.6.1" } }, "sha512-mTel7ipT0yNjKILIan04bkJkuCzUUkm2SeEaTads8VfEecCh+ltXchdq6DovXJqzQAXuR2P9cxZB47Lg4klriA=="],
+    "metro-config": ["metro-config@0.83.1", "", { "dependencies": { "connect": "^3.6.5", "cosmiconfig": "^5.0.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.1", "metro-cache": "0.83.1", "metro-core": "0.83.1", "metro-runtime": "0.83.1" } }, "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA=="],
 
-    "metro-core": ["metro-core@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.3" } }, "sha512-M+X59lm7oBmJZamc96usuF1kusd5YimqG/q97g4Ac7slnJ3YiGglW5CsOlicTR5EWf8MQFxxjDoB6ytTqRe8Hw=="],
+    "metro-core": ["metro-core@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.1" } }, "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q=="],
 
     "metro-file-map": ["metro-file-map@0.83.3", "", { "dependencies": { "debug": "^4.4.0", "fb-watchman": "^2.0.0", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "nullthrows": "^1.1.1", "walker": "^1.0.7" } }, "sha512-jg5AcyE0Q9Xbbu/4NAwwZkmQn7doJCKGW0SLeSJmzNB9Z24jBe0AL2PHNMy4eu0JiKtNWHz9IiONGZWq7hjVTA=="],
 
@@ -2054,11 +2054,11 @@
 
     "metro-resolver": ["metro-resolver@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-0js+zwI5flFxb1ktmR///bxHYg7OLpRpWZlBBruYG8OKYxeMP7SV0xQ/o/hUelrEMdK4LJzqVtHAhBm25LVfAQ=="],
 
-    "metro-runtime": ["metro-runtime@0.83.3", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-JHCJb9ebr9rfJ+LcssFYA2x1qPYuSD/bbePupIGhpMrsla7RCwC/VL3yJ9cSU+nUhU4c9Ixxy8tBta+JbDeZWw=="],
+    "metro-runtime": ["metro-runtime@0.83.1", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA=="],
 
-    "metro-source-map": ["metro-source-map@0.83.3", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.3", "nullthrows": "^1.1.1", "ob1": "0.83.3", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg=="],
+    "metro-source-map": ["metro-source-map@0.83.1", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.1", "nullthrows": "^1.1.1", "ob1": "0.83.1", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A=="],
 
-    "metro-symbolicate": ["metro-symbolicate@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.3", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-F/YChgKd6KbFK3eUR5HdUsfBqVsanf5lNTwFd4Ca7uuxnHgBC3kR/Hba/RGkenR3pZaGNp5Bu9ZqqP52Wyhomw=="],
+    "metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
 
     "metro-transform-plugins": ["metro-transform-plugins@0.83.3", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-eRGoKJU6jmqOakBMH5kUB7VitEWiNrDzBHpYbkBXW7C5fUGeOd2CyqrosEzbMK5VMiZYyOcNFEphvxk3OXey2A=="],
 
@@ -2144,7 +2144,7 @@
 
     "nypm": ["nypm@0.6.2", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.2", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "tinyexec": "^1.0.1" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g=="],
 
-    "ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
+    "ob1": ["ob1@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -2326,7 +2326,7 @@
 
     "react-json-tree": ["react-json-tree@0.20.0", "", { "dependencies": { "@types/lodash": "^4.17.15", "react-base16-styling": "^0.10.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-h+f9fUNAxzBx1rbrgUF7+zSWKGHDtt2VPYLErIuB0JyKGnWgFMM21ksqQyb3EXwXNnoMW2rdE5kuAaubgGOx2Q=="],
 
-    "react-native": ["react-native@0.81.5", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.5", "@react-native/codegen": "0.81.5", "@react-native/community-cli-plugin": "0.81.5", "@react-native/gradle-plugin": "0.81.5", "@react-native/js-polyfills": "0.81.5", "@react-native/normalize-colors": "0.81.5", "@react-native/virtualized-lists": "0.81.5", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw=="],
+    "react-native": ["react-native@0.81.4", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.4", "@react-native/codegen": "0.81.4", "@react-native/community-cli-plugin": "0.81.4", "@react-native/gradle-plugin": "0.81.4", "@react-native/js-polyfills": "0.81.4", "@react-native/normalize-colors": "0.81.4", "@react-native/virtualized-lists": "0.81.4", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ=="],
 
     "react-native-audio-api": ["react-native-audio-api@0.7.2", "", { "peerDependencies": { "react": "*", "react-native": "*" }, "bin": { "setup-rn-audio-api-web": "scripts/setup-rn-audio-api-web.js" } }, "sha512-FAmULH+7gStZUDeFNYJdJgilBNXQTMU7LBZShzMd34JVfx0A5NWIyiXoonuePC+cCzxY/ujePHlE3kJ3riyRDg=="],
 
@@ -2824,6 +2824,8 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "@expo/cli/@react-native/dev-middleware": ["@react-native/dev-middleware@0.81.5", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "@react-native/debugger-frontend": "0.81.5", "chrome-launcher": "^0.15.2", "chromium-edge-launcher": "^0.2.0", "connect": "^3.6.5", "debug": "^4.4.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "open": "^7.0.3", "serve-static": "^1.16.2", "ws": "^6.2.3" } }, "sha512-WfPfZzboYgo/TUtysuD5xyANzzfka8Ebni6RIb2wDxhb56ERi7qDrE4xGhtPsjCL4pQBXSVxyIlCy0d8I6EgGA=="],
+
     "@expo/cli/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "@expo/cli/glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
@@ -2856,6 +2858,18 @@
 
     "@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
+    "@expo/metro/metro": ["metro@0.83.3", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.32.0", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.3", "metro-cache": "0.83.3", "metro-cache-key": "0.83.3", "metro-config": "0.83.3", "metro-core": "0.83.3", "metro-file-map": "0.83.3", "metro-resolver": "0.83.3", "metro-runtime": "0.83.3", "metro-source-map": "0.83.3", "metro-symbolicate": "0.83.3", "metro-transform-plugins": "0.83.3", "metro-transform-worker": "0.83.3", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-+rP+/GieOzkt97hSJ0MrPOuAH/jpaS21ZDvL9DJ35QYRDlQcwzcvUlGUf79AnQxq/2NPiS/AULhhM4TKutIt8Q=="],
+
+    "@expo/metro/metro-config": ["metro-config@0.83.3", "", { "dependencies": { "connect": "^3.6.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.3", "metro-cache": "0.83.3", "metro-core": "0.83.3", "metro-runtime": "0.83.3", "yaml": "^2.6.1" } }, "sha512-mTel7ipT0yNjKILIan04bkJkuCzUUkm2SeEaTads8VfEecCh+ltXchdq6DovXJqzQAXuR2P9cxZB47Lg4klriA=="],
+
+    "@expo/metro/metro-core": ["metro-core@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.3" } }, "sha512-M+X59lm7oBmJZamc96usuF1kusd5YimqG/q97g4Ac7slnJ3YiGglW5CsOlicTR5EWf8MQFxxjDoB6ytTqRe8Hw=="],
+
+    "@expo/metro/metro-runtime": ["metro-runtime@0.83.3", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-JHCJb9ebr9rfJ+LcssFYA2x1qPYuSD/bbePupIGhpMrsla7RCwC/VL3yJ9cSU+nUhU4c9Ixxy8tBta+JbDeZWw=="],
+
+    "@expo/metro/metro-source-map": ["metro-source-map@0.83.3", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.3", "nullthrows": "^1.1.1", "ob1": "0.83.3", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg=="],
+
+    "@expo/metro/metro-symbolicate": ["metro-symbolicate@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.3", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-F/YChgKd6KbFK3eUR5HdUsfBqVsanf5lNTwFd4Ca7uuxnHgBC3kR/Hba/RGkenR3pZaGNp5Bu9ZqqP52Wyhomw=="],
+
     "@expo/metro-config/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
     "@expo/metro-config/glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
@@ -2865,6 +2879,8 @@
     "@expo/metro-config/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
     "@expo/package-manager/ora": ["ora@3.4.0", "", { "dependencies": { "chalk": "^2.4.2", "cli-cursor": "^2.1.0", "cli-spinners": "^2.0.0", "log-symbols": "^2.2.0", "strip-ansi": "^5.2.0", "wcwidth": "^1.0.1" } }, "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg=="],
+
+    "@expo/prebuild-config/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
 
     "@expo/xcpretty/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
@@ -2898,15 +2914,7 @@
 
     "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@15.0.2", "", { "dependencies": { "@octokit/openapi-types": "^26.0.0" } }, "sha512-rR+5VRjhYSer7sC51krfCctQhVTmjyUMAaShfPB8mscVa8tSoLyon3coxQmXu0ahJoLVWl8dSGD/3OGZlFV44Q=="],
 
-    "@react-native-ai/apple/react-native": ["react-native@0.81.4", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.4", "@react-native/codegen": "0.81.4", "@react-native/community-cli-plugin": "0.81.4", "@react-native/gradle-plugin": "0.81.4", "@react-native/js-polyfills": "0.81.4", "@react-native/normalize-colors": "0.81.4", "@react-native/virtualized-lists": "0.81.4", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ=="],
-
-    "@react-native-ai/dev-tools/react-native": ["react-native@0.81.4", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.4", "@react-native/codegen": "0.81.4", "@react-native/community-cli-plugin": "0.81.4", "@react-native/gradle-plugin": "0.81.4", "@react-native/js-polyfills": "0.81.4", "@react-native/normalize-colors": "0.81.4", "@react-native/virtualized-lists": "0.81.4", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ=="],
-
-    "@react-native-ai/llama/react-native": ["react-native@0.81.4", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.4", "@react-native/codegen": "0.81.4", "@react-native/community-cli-plugin": "0.81.4", "@react-native/gradle-plugin": "0.81.4", "@react-native/js-polyfills": "0.81.4", "@react-native/normalize-colors": "0.81.4", "@react-native/virtualized-lists": "0.81.4", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ=="],
-
-    "@react-native-ai/mlc/react-native": ["react-native@0.81.4", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.4", "@react-native/codegen": "0.81.4", "@react-native/community-cli-plugin": "0.81.4", "@react-native/gradle-plugin": "0.81.4", "@react-native/js-polyfills": "0.81.4", "@react-native/normalize-colors": "0.81.4", "@react-native/virtualized-lists": "0.81.4", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ=="],
-
-    "@react-native/babel-plugin-codegen/@react-native/codegen": ["@react-native/codegen@0.81.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw=="],
+    "@react-native-ai/example/react-native": ["react-native@0.81.5", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.5", "@react-native/codegen": "0.81.5", "@react-native/community-cli-plugin": "0.81.5", "@react-native/gradle-plugin": "0.81.5", "@react-native/js-polyfills": "0.81.5", "@react-native/normalize-colors": "0.81.5", "@react-native/virtualized-lists": "0.81.5", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw=="],
 
     "@react-native/codegen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -3036,6 +3044,8 @@
 
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
+    "expo-system-ui/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
+
     "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "express/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
@@ -3106,13 +3116,37 @@
 
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
-    "metro/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
+    "metro/metro-babel-transformer": ["metro-babel-transformer@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "flow-enums-runtime": "^0.0.6", "hermes-parser": "0.29.1", "nullthrows": "^1.1.1" } }, "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ=="],
+
+    "metro/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
+
+    "metro/metro-cache-key": ["metro-cache-key@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg=="],
+
+    "metro/metro-file-map": ["metro-file-map@0.83.1", "", { "dependencies": { "debug": "^4.4.0", "fb-watchman": "^2.0.0", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "nullthrows": "^1.1.1", "walker": "^1.0.7" } }, "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w=="],
+
+    "metro/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
+
+    "metro/metro-transform-plugins": ["metro-transform-plugins@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ=="],
+
+    "metro/metro-transform-worker": ["metro-transform-worker@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "metro": "0.83.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-minify-terser": "0.83.1", "metro-source-map": "0.83.1", "metro-transform-plugins": "0.83.1", "nullthrows": "^1.1.1" } }, "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q=="],
 
     "metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
+
+    "metro-cache/metro-core": ["metro-core@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.3" } }, "sha512-M+X59lm7oBmJZamc96usuF1kusd5YimqG/q97g4Ac7slnJ3YiGglW5CsOlicTR5EWf8MQFxxjDoB6ytTqRe8Hw=="],
+
+    "metro-config/cosmiconfig": ["cosmiconfig@5.2.1", "", { "dependencies": { "import-fresh": "^2.0.0", "is-directory": "^0.3.1", "js-yaml": "^3.13.1", "parse-json": "^4.0.0" } }, "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA=="],
+
+    "metro-config/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
+
+    "metro-core/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
+
+    "metro-transform-worker/metro": ["metro@0.83.3", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.32.0", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.3", "metro-cache": "0.83.3", "metro-cache-key": "0.83.3", "metro-config": "0.83.3", "metro-core": "0.83.3", "metro-file-map": "0.83.3", "metro-resolver": "0.83.3", "metro-runtime": "0.83.3", "metro-source-map": "0.83.3", "metro-symbolicate": "0.83.3", "metro-transform-plugins": "0.83.3", "metro-transform-worker": "0.83.3", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-+rP+/GieOzkt97hSJ0MrPOuAH/jpaS21ZDvL9DJ35QYRDlQcwzcvUlGUf79AnQxq/2NPiS/AULhhM4TKutIt8Q=="],
+
+    "metro-transform-worker/metro-source-map": ["metro-source-map@0.83.3", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.3", "nullthrows": "^1.1.1", "ob1": "0.83.3", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -3250,6 +3284,12 @@
 
     "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "@expo/cli/@react-native/dev-middleware/@react-native/debugger-frontend": ["@react-native/debugger-frontend@0.81.5", "", {}, "sha512-bnd9FSdWKx2ncklOetCgrlwqSGhMHP2zOxObJbOWXoj7GHEmih4MKarBo5/a8gX8EfA1EwRATdfNBQ81DY+h+w=="],
+
+    "@expo/cli/@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
+
+    "@expo/cli/@react-native/dev-middleware/ws": ["ws@6.2.3", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA=="],
+
     "@expo/cli/glob/minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
 
     "@expo/cli/glob/path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
@@ -3286,6 +3326,16 @@
 
     "@expo/metro-config/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "@expo/metro/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
+
+    "@expo/metro/metro/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
+
+    "@expo/metro/metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "@expo/metro/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "@expo/metro/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
+
     "@expo/package-manager/ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@expo/package-manager/ora/cli-cursor": ["cli-cursor@2.1.0", "", { "dependencies": { "restore-cursor": "^2.0.0" } }, "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw=="],
@@ -3310,87 +3360,25 @@
 
     "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@26.0.0", "", {}, "sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA=="],
 
-    "@react-native-ai/apple/react-native/@react-native/assets-registry": ["@react-native/assets-registry@0.81.4", "", {}, "sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA=="],
+    "@react-native-ai/example/react-native/@react-native/assets-registry": ["@react-native/assets-registry@0.81.5", "", {}, "sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w=="],
 
-    "@react-native-ai/apple/react-native/@react-native/codegen": ["@react-native/codegen@0.81.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw=="],
+    "@react-native-ai/example/react-native/@react-native/codegen": ["@react-native/codegen@0.81.5", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin": ["@react-native/community-cli-plugin@0.81.4", "", { "dependencies": { "@react-native/dev-middleware": "0.81.4", "debug": "^4.4.0", "invariant": "^2.2.4", "metro": "^0.83.1", "metro-config": "^0.83.1", "metro-core": "^0.83.1", "semver": "^7.1.3" }, "peerDependencies": { "@react-native-community/cli": "*", "@react-native/metro-config": "*" }, "optionalPeers": ["@react-native-community/cli", "@react-native/metro-config"] }, "sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin": ["@react-native/community-cli-plugin@0.81.5", "", { "dependencies": { "@react-native/dev-middleware": "0.81.5", "debug": "^4.4.0", "invariant": "^2.2.4", "metro": "^0.83.1", "metro-config": "^0.83.1", "metro-core": "^0.83.1", "semver": "^7.1.3" }, "peerDependencies": { "@react-native-community/cli": "*", "@react-native/metro-config": "*" }, "optionalPeers": ["@react-native-community/cli", "@react-native/metro-config"] }, "sha512-yWRlmEOtcyvSZ4+OvqPabt+NS36vg0K/WADTQLhrYrm9qdZSuXmq8PmdJWz/68wAqKQ+4KTILiq2kjRQwnyhQw=="],
 
-    "@react-native-ai/apple/react-native/@react-native/gradle-plugin": ["@react-native/gradle-plugin@0.81.4", "", {}, "sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw=="],
+    "@react-native-ai/example/react-native/@react-native/gradle-plugin": ["@react-native/gradle-plugin@0.81.5", "", {}, "sha512-hORRlNBj+ReNMLo9jme3yQ6JQf4GZpVEBLxmTXGGlIL78MAezDZr5/uq9dwElSbcGmLEgeiax6e174Fie6qPLg=="],
 
-    "@react-native-ai/apple/react-native/@react-native/js-polyfills": ["@react-native/js-polyfills@0.81.4", "", {}, "sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w=="],
+    "@react-native-ai/example/react-native/@react-native/js-polyfills": ["@react-native/js-polyfills@0.81.5", "", {}, "sha512-fB7M1CMOCIUudTRuj7kzxIBTVw2KXnsgbQ6+4cbqSxo8NmRRhA0Ul4ZUzZj3rFd3VznTL4Brmocv1oiN0bWZ8w=="],
 
-    "@react-native-ai/apple/react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.4", "", {}, "sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg=="],
+    "@react-native-ai/example/react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
 
-    "@react-native-ai/apple/react-native/@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.4", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA=="],
+    "@react-native-ai/example/react-native/@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.5", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw=="],
 
-    "@react-native-ai/apple/react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+    "@react-native-ai/example/react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "@react-native-ai/apple/react-native/metro-runtime": ["metro-runtime@0.83.1", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA=="],
+    "@react-native-ai/example/react-native/metro-runtime": ["metro-runtime@0.83.3", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-JHCJb9ebr9rfJ+LcssFYA2x1qPYuSD/bbePupIGhpMrsla7RCwC/VL3yJ9cSU+nUhU4c9Ixxy8tBta+JbDeZWw=="],
 
-    "@react-native-ai/apple/react-native/metro-source-map": ["metro-source-map@0.83.1", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.1", "nullthrows": "^1.1.1", "ob1": "0.83.1", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/assets-registry": ["@react-native/assets-registry@0.81.4", "", {}, "sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/codegen": ["@react-native/codegen@0.81.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin": ["@react-native/community-cli-plugin@0.81.4", "", { "dependencies": { "@react-native/dev-middleware": "0.81.4", "debug": "^4.4.0", "invariant": "^2.2.4", "metro": "^0.83.1", "metro-config": "^0.83.1", "metro-core": "^0.83.1", "semver": "^7.1.3" }, "peerDependencies": { "@react-native-community/cli": "*", "@react-native/metro-config": "*" }, "optionalPeers": ["@react-native-community/cli", "@react-native/metro-config"] }, "sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/gradle-plugin": ["@react-native/gradle-plugin@0.81.4", "", {}, "sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/js-polyfills": ["@react-native/js-polyfills@0.81.4", "", {}, "sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.4", "", {}, "sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.4", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA=="],
-
-    "@react-native-ai/dev-tools/react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "@react-native-ai/dev-tools/react-native/metro-runtime": ["metro-runtime@0.83.1", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA=="],
-
-    "@react-native-ai/dev-tools/react-native/metro-source-map": ["metro-source-map@0.83.1", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.1", "nullthrows": "^1.1.1", "ob1": "0.83.1", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A=="],
-
-    "@react-native-ai/llama/react-native/@react-native/assets-registry": ["@react-native/assets-registry@0.81.4", "", {}, "sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA=="],
-
-    "@react-native-ai/llama/react-native/@react-native/codegen": ["@react-native/codegen@0.81.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin": ["@react-native/community-cli-plugin@0.81.4", "", { "dependencies": { "@react-native/dev-middleware": "0.81.4", "debug": "^4.4.0", "invariant": "^2.2.4", "metro": "^0.83.1", "metro-config": "^0.83.1", "metro-core": "^0.83.1", "semver": "^7.1.3" }, "peerDependencies": { "@react-native-community/cli": "*", "@react-native/metro-config": "*" }, "optionalPeers": ["@react-native-community/cli", "@react-native/metro-config"] }, "sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA=="],
-
-    "@react-native-ai/llama/react-native/@react-native/gradle-plugin": ["@react-native/gradle-plugin@0.81.4", "", {}, "sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw=="],
-
-    "@react-native-ai/llama/react-native/@react-native/js-polyfills": ["@react-native/js-polyfills@0.81.4", "", {}, "sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w=="],
-
-    "@react-native-ai/llama/react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.4", "", {}, "sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg=="],
-
-    "@react-native-ai/llama/react-native/@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.4", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA=="],
-
-    "@react-native-ai/llama/react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "@react-native-ai/llama/react-native/metro-runtime": ["metro-runtime@0.83.1", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA=="],
-
-    "@react-native-ai/llama/react-native/metro-source-map": ["metro-source-map@0.83.1", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.1", "nullthrows": "^1.1.1", "ob1": "0.83.1", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/assets-registry": ["@react-native/assets-registry@0.81.4", "", {}, "sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/codegen": ["@react-native/codegen@0.81.4", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin": ["@react-native/community-cli-plugin@0.81.4", "", { "dependencies": { "@react-native/dev-middleware": "0.81.4", "debug": "^4.4.0", "invariant": "^2.2.4", "metro": "^0.83.1", "metro-config": "^0.83.1", "metro-core": "^0.83.1", "semver": "^7.1.3" }, "peerDependencies": { "@react-native-community/cli": "*", "@react-native/metro-config": "*" }, "optionalPeers": ["@react-native-community/cli", "@react-native/metro-config"] }, "sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/gradle-plugin": ["@react-native/gradle-plugin@0.81.4", "", {}, "sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/js-polyfills": ["@react-native/js-polyfills@0.81.4", "", {}, "sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.4", "", {}, "sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.4", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA=="],
-
-    "@react-native-ai/mlc/react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "@react-native-ai/mlc/react-native/metro-runtime": ["metro-runtime@0.83.1", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA=="],
-
-    "@react-native-ai/mlc/react-native/metro-source-map": ["metro-source-map@0.83.1", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.1", "nullthrows": "^1.1.1", "ob1": "0.83.1", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A=="],
-
-    "@react-native/babel-plugin-codegen/@react-native/codegen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+    "@react-native-ai/example/react-native/metro-source-map": ["metro-source-map@0.83.3", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.3", "nullthrows": "^1.1.1", "ob1": "0.83.3", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg=="],
 
     "@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
@@ -3540,7 +3528,33 @@
 
     "metro-babel-transformer/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
 
-    "metro/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
+    "metro-config/cosmiconfig/import-fresh": ["import-fresh@2.0.0", "", { "dependencies": { "caller-path": "^2.0.0", "resolve-from": "^3.0.0" } }, "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg=="],
+
+    "metro-config/cosmiconfig/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+
+    "metro-config/cosmiconfig/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
+
+    "metro-transform-worker/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
+
+    "metro-transform-worker/metro/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
+
+    "metro-transform-worker/metro/metro-config": ["metro-config@0.83.3", "", { "dependencies": { "connect": "^3.6.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.3", "metro-cache": "0.83.3", "metro-core": "0.83.3", "metro-runtime": "0.83.3", "yaml": "^2.6.1" } }, "sha512-mTel7ipT0yNjKILIan04bkJkuCzUUkm2SeEaTads8VfEecCh+ltXchdq6DovXJqzQAXuR2P9cxZB47Lg4klriA=="],
+
+    "metro-transform-worker/metro/metro-core": ["metro-core@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.3" } }, "sha512-M+X59lm7oBmJZamc96usuF1kusd5YimqG/q97g4Ac7slnJ3YiGglW5CsOlicTR5EWf8MQFxxjDoB6ytTqRe8Hw=="],
+
+    "metro-transform-worker/metro/metro-runtime": ["metro-runtime@0.83.3", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-JHCJb9ebr9rfJ+LcssFYA2x1qPYuSD/bbePupIGhpMrsla7RCwC/VL3yJ9cSU+nUhU4c9Ixxy8tBta+JbDeZWw=="],
+
+    "metro-transform-worker/metro/metro-symbolicate": ["metro-symbolicate@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.3", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-F/YChgKd6KbFK3eUR5HdUsfBqVsanf5lNTwFd4Ca7uuxnHgBC3kR/Hba/RGkenR3pZaGNp5Bu9ZqqP52Wyhomw=="],
+
+    "metro-transform-worker/metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "metro-transform-worker/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "metro-transform-worker/metro-source-map/metro-symbolicate": ["metro-symbolicate@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.3", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-F/YChgKd6KbFK3eUR5HdUsfBqVsanf5lNTwFd4Ca7uuxnHgBC3kR/Hba/RGkenR3pZaGNp5Bu9ZqqP52Wyhomw=="],
+
+    "metro-transform-worker/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
+
+    "metro/metro-transform-worker/metro-minify-terser": ["metro-minify-terser@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A=="],
 
     "metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -3588,6 +3602,10 @@
 
     "@commitlint/top-level/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
 
+    "@expo/cli/@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+
+    "@expo/cli/@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+
     "@expo/cli/glob/path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "@expo/cli/ora/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
@@ -3608,6 +3626,10 @@
 
     "@expo/metro-config/glob/path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
+    "@expo/metro/metro/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
+
+    "@expo/metro/metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "@expo/package-manager/ora/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
     "@expo/package-manager/ora/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -3620,55 +3642,21 @@
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware": ["@react-native/dev-middleware@0.81.4", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "@react-native/debugger-frontend": "0.81.4", "chrome-launcher": "^0.15.2", "chromium-edge-launcher": "^0.2.0", "connect": "^3.6.5", "debug": "^4.4.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "open": "^7.0.3", "serve-static": "^1.16.2", "ws": "^6.2.3" } }, "sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware": ["@react-native/dev-middleware@0.81.5", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "@react-native/debugger-frontend": "0.81.5", "chrome-launcher": "^0.15.2", "chromium-edge-launcher": "^0.2.0", "connect": "^3.6.5", "debug": "^4.4.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "open": "^7.0.3", "serve-static": "^1.16.2", "ws": "^6.2.3" } }, "sha512-WfPfZzboYgo/TUtysuD5xyANzzfka8Ebni6RIb2wDxhb56ERi7qDrE4xGhtPsjCL4pQBXSVxyIlCy0d8I6EgGA=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro": ["metro@0.83.1", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.29.1", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-config": "0.83.1", "metro-core": "0.83.1", "metro-file-map": "0.83.1", "metro-resolver": "0.83.1", "metro-runtime": "0.83.1", "metro-source-map": "0.83.1", "metro-symbolicate": "0.83.1", "metro-transform-plugins": "0.83.1", "metro-transform-worker": "0.83.1", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro": ["metro@0.83.3", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.32.0", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.3", "metro-cache": "0.83.3", "metro-cache-key": "0.83.3", "metro-config": "0.83.3", "metro-core": "0.83.3", "metro-file-map": "0.83.3", "metro-resolver": "0.83.3", "metro-runtime": "0.83.3", "metro-source-map": "0.83.3", "metro-symbolicate": "0.83.3", "metro-transform-plugins": "0.83.3", "metro-transform-worker": "0.83.3", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-+rP+/GieOzkt97hSJ0MrPOuAH/jpaS21ZDvL9DJ35QYRDlQcwzcvUlGUf79AnQxq/2NPiS/AULhhM4TKutIt8Q=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-config": ["metro-config@0.83.1", "", { "dependencies": { "connect": "^3.6.5", "cosmiconfig": "^5.0.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.1", "metro-cache": "0.83.1", "metro-core": "0.83.1", "metro-runtime": "0.83.1" } }, "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro-config": ["metro-config@0.83.3", "", { "dependencies": { "connect": "^3.6.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.3", "metro-cache": "0.83.3", "metro-core": "0.83.3", "metro-runtime": "0.83.3", "yaml": "^2.6.1" } }, "sha512-mTel7ipT0yNjKILIan04bkJkuCzUUkm2SeEaTads8VfEecCh+ltXchdq6DovXJqzQAXuR2P9cxZB47Lg4klriA=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.1" } }, "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.3" } }, "sha512-M+X59lm7oBmJZamc96usuF1kusd5YimqG/q97g4Ac7slnJ3YiGglW5CsOlicTR5EWf8MQFxxjDoB6ytTqRe8Hw=="],
 
-    "@react-native-ai/apple/react-native/metro-source-map/metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
+    "@react-native-ai/example/react-native/metro-source-map/metro-symbolicate": ["metro-symbolicate@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.3", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-F/YChgKd6KbFK3eUR5HdUsfBqVsanf5lNTwFd4Ca7uuxnHgBC3kR/Hba/RGkenR3pZaGNp5Bu9ZqqP52Wyhomw=="],
 
-    "@react-native-ai/apple/react-native/metro-source-map/ob1": ["ob1@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware": ["@react-native/dev-middleware@0.81.4", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "@react-native/debugger-frontend": "0.81.4", "chrome-launcher": "^0.15.2", "chromium-edge-launcher": "^0.2.0", "connect": "^3.6.5", "debug": "^4.4.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "open": "^7.0.3", "serve-static": "^1.16.2", "ws": "^6.2.3" } }, "sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro": ["metro@0.83.1", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.29.1", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-config": "0.83.1", "metro-core": "0.83.1", "metro-file-map": "0.83.1", "metro-resolver": "0.83.1", "metro-runtime": "0.83.1", "metro-source-map": "0.83.1", "metro-symbolicate": "0.83.1", "metro-transform-plugins": "0.83.1", "metro-transform-worker": "0.83.1", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-config": ["metro-config@0.83.1", "", { "dependencies": { "connect": "^3.6.5", "cosmiconfig": "^5.0.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.1", "metro-cache": "0.83.1", "metro-core": "0.83.1", "metro-runtime": "0.83.1" } }, "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.1" } }, "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q=="],
-
-    "@react-native-ai/dev-tools/react-native/metro-source-map/metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
-
-    "@react-native-ai/dev-tools/react-native/metro-source-map/ob1": ["ob1@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware": ["@react-native/dev-middleware@0.81.4", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "@react-native/debugger-frontend": "0.81.4", "chrome-launcher": "^0.15.2", "chromium-edge-launcher": "^0.2.0", "connect": "^3.6.5", "debug": "^4.4.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "open": "^7.0.3", "serve-static": "^1.16.2", "ws": "^6.2.3" } }, "sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro": ["metro@0.83.1", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.29.1", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-config": "0.83.1", "metro-core": "0.83.1", "metro-file-map": "0.83.1", "metro-resolver": "0.83.1", "metro-runtime": "0.83.1", "metro-source-map": "0.83.1", "metro-symbolicate": "0.83.1", "metro-transform-plugins": "0.83.1", "metro-transform-worker": "0.83.1", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-config": ["metro-config@0.83.1", "", { "dependencies": { "connect": "^3.6.5", "cosmiconfig": "^5.0.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.1", "metro-cache": "0.83.1", "metro-core": "0.83.1", "metro-runtime": "0.83.1" } }, "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.1" } }, "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q=="],
-
-    "@react-native-ai/llama/react-native/metro-source-map/metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
-
-    "@react-native-ai/llama/react-native/metro-source-map/ob1": ["ob1@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware": ["@react-native/dev-middleware@0.81.4", "", { "dependencies": { "@isaacs/ttlcache": "^1.4.1", "@react-native/debugger-frontend": "0.81.4", "chrome-launcher": "^0.15.2", "chromium-edge-launcher": "^0.2.0", "connect": "^3.6.5", "debug": "^4.4.0", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "open": "^7.0.3", "serve-static": "^1.16.2", "ws": "^6.2.3" } }, "sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro": ["metro@0.83.1", "", { "dependencies": { "@babel/code-frame": "^7.24.7", "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "@babel/types": "^7.25.2", "accepts": "^1.3.7", "chalk": "^4.0.0", "ci-info": "^2.0.0", "connect": "^3.6.5", "debug": "^4.4.0", "error-stack-parser": "^2.0.6", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "hermes-parser": "0.29.1", "image-size": "^1.0.2", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "jsc-safe-url": "^0.2.2", "lodash.throttle": "^4.1.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-config": "0.83.1", "metro-core": "0.83.1", "metro-file-map": "0.83.1", "metro-resolver": "0.83.1", "metro-runtime": "0.83.1", "metro-source-map": "0.83.1", "metro-symbolicate": "0.83.1", "metro-transform-plugins": "0.83.1", "metro-transform-worker": "0.83.1", "mime-types": "^2.1.27", "nullthrows": "^1.1.1", "serialize-error": "^2.1.0", "source-map": "^0.5.6", "throat": "^5.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "bin": { "metro": "src/cli.js" } }, "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-config": ["metro-config@0.83.1", "", { "dependencies": { "connect": "^3.6.5", "cosmiconfig": "^5.0.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.1", "metro-cache": "0.83.1", "metro-core": "0.83.1", "metro-runtime": "0.83.1" } }, "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-core": ["metro-core@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "lodash.throttle": "^4.1.1", "metro-resolver": "0.83.1" } }, "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q=="],
-
-    "@react-native-ai/mlc/react-native/metro-source-map/metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
-
-    "@react-native-ai/mlc/react-native/metro-source-map/ob1": ["ob1@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ=="],
+    "@react-native-ai/example/react-native/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
 
     "@vue/compiler-core/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "babel-preset-expo/@react-native/babel-preset/@react-native/babel-plugin-codegen/@react-native/codegen": ["@react-native/codegen@0.81.5", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/parser": "^7.25.3", "glob": "^7.1.1", "hermes-parser": "0.29.1", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "yargs": "^17.6.2" } }, "sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g=="],
 
     "conventional-changelog-writer/meow/read-pkg-up/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
@@ -3736,6 +3724,14 @@
 
     "is-git-repository/execa/onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
+    "metro-config/cosmiconfig/import-fresh/resolve-from": ["resolve-from@3.0.0", "", {}, "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw=="],
+
+    "metro-config/cosmiconfig/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "metro-transform-worker/metro/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
+
+    "metro-transform-worker/metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "react-native-blob-util/glob/path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "react-native-builder-bob/babel-plugin-syntax-hermes-parser/hermes-parser/hermes-estree": ["hermes-estree@0.28.1", "", {}, "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ=="],
@@ -3768,133 +3764,21 @@
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/@react-native/debugger-frontend": ["@react-native/debugger-frontend@0.81.4", "", {}, "sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/@react-native/debugger-frontend": ["@react-native/debugger-frontend@0.81.5", "", {}, "sha512-bnd9FSdWKx2ncklOetCgrlwqSGhMHP2zOxObJbOWXoj7GHEmih4MKarBo5/a8gX8EfA1EwRATdfNBQ81DY+h+w=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-babel-transformer": ["metro-babel-transformer@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "flow-enums-runtime": "^0.0.6", "hermes-parser": "0.29.1", "nullthrows": "^1.1.1" } }, "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro/metro-symbolicate": ["metro-symbolicate@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.3", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-F/YChgKd6KbFK3eUR5HdUsfBqVsanf5lNTwFd4Ca7uuxnHgBC3kR/Hba/RGkenR3pZaGNp5Bu9ZqqP52Wyhomw=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-cache-key": ["metro-cache-key@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-file-map": ["metro-file-map@0.83.1", "", { "dependencies": { "debug": "^4.4.0", "fb-watchman": "^2.0.0", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "nullthrows": "^1.1.1", "walker": "^1.0.7" } }, "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-transform-plugins": ["metro-transform-plugins@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker": ["metro-transform-worker@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "metro": "0.83.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-minify-terser": "0.83.1", "metro-source-map": "0.83.1", "metro-transform-plugins": "0.83.1", "nullthrows": "^1.1.1" } }, "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig": ["cosmiconfig@5.2.1", "", { "dependencies": { "import-fresh": "^2.0.0", "is-directory": "^0.3.1", "js-yaml": "^3.13.1", "parse-json": "^4.0.0" } }, "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-config/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-core/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/@react-native/debugger-frontend": ["@react-native/debugger-frontend@0.81.4", "", {}, "sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-babel-transformer": ["metro-babel-transformer@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "flow-enums-runtime": "^0.0.6", "hermes-parser": "0.29.1", "nullthrows": "^1.1.1" } }, "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-cache-key": ["metro-cache-key@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-file-map": ["metro-file-map@0.83.1", "", { "dependencies": { "debug": "^4.4.0", "fb-watchman": "^2.0.0", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "nullthrows": "^1.1.1", "walker": "^1.0.7" } }, "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-transform-plugins": ["metro-transform-plugins@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker": ["metro-transform-worker@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "metro": "0.83.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-minify-terser": "0.83.1", "metro-source-map": "0.83.1", "metro-transform-plugins": "0.83.1", "nullthrows": "^1.1.1" } }, "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig": ["cosmiconfig@5.2.1", "", { "dependencies": { "import-fresh": "^2.0.0", "is-directory": "^0.3.1", "js-yaml": "^3.13.1", "parse-json": "^4.0.0" } }, "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-config/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-core/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/@react-native/debugger-frontend": ["@react-native/debugger-frontend@0.81.4", "", {}, "sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-babel-transformer": ["metro-babel-transformer@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "flow-enums-runtime": "^0.0.6", "hermes-parser": "0.29.1", "nullthrows": "^1.1.1" } }, "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-cache-key": ["metro-cache-key@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-file-map": ["metro-file-map@0.83.1", "", { "dependencies": { "debug": "^4.4.0", "fb-watchman": "^2.0.0", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "nullthrows": "^1.1.1", "walker": "^1.0.7" } }, "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-transform-plugins": ["metro-transform-plugins@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker": ["metro-transform-worker@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "metro": "0.83.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-minify-terser": "0.83.1", "metro-source-map": "0.83.1", "metro-transform-plugins": "0.83.1", "nullthrows": "^1.1.1" } }, "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig": ["cosmiconfig@5.2.1", "", { "dependencies": { "import-fresh": "^2.0.0", "is-directory": "^0.3.1", "js-yaml": "^3.13.1", "parse-json": "^4.0.0" } }, "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-config/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-core/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/@react-native/debugger-frontend": ["@react-native/debugger-frontend@0.81.4", "", {}, "sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-babel-transformer": ["metro-babel-transformer@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "flow-enums-runtime": "^0.0.6", "hermes-parser": "0.29.1", "nullthrows": "^1.1.1" } }, "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-cache-key": ["metro-cache-key@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-file-map": ["metro-file-map@0.83.1", "", { "dependencies": { "debug": "^4.4.0", "fb-watchman": "^2.0.0", "flow-enums-runtime": "^0.0.6", "graceful-fs": "^4.2.4", "invariant": "^2.2.4", "jest-worker": "^29.7.0", "micromatch": "^4.0.4", "nullthrows": "^1.1.1", "walker": "^1.0.7" } }, "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-symbolicate": ["metro-symbolicate@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-source-map": "0.83.1", "nullthrows": "^1.1.1", "source-map": "^0.5.6", "vlq": "^1.0.0" }, "bin": { "metro-symbolicate": "src/index.js" } }, "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-transform-plugins": ["metro-transform-plugins@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/template": "^7.25.0", "@babel/traverse": "^7.25.3", "flow-enums-runtime": "^0.0.6", "nullthrows": "^1.1.1" } }, "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker": ["metro-transform-worker@0.83.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.25.0", "@babel/parser": "^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "metro": "0.83.1", "metro-babel-transformer": "0.83.1", "metro-cache": "0.83.1", "metro-cache-key": "0.83.1", "metro-minify-terser": "0.83.1", "metro-source-map": "0.83.1", "metro-transform-plugins": "0.83.1", "nullthrows": "^1.1.1" } }, "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig": ["cosmiconfig@5.2.1", "", { "dependencies": { "import-fresh": "^2.0.0", "is-directory": "^0.3.1", "js-yaml": "^3.13.1", "parse-json": "^4.0.0" } }, "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-config/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-core/metro-resolver": ["metro-resolver@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g=="],
+    "babel-preset-expo/@react-native/babel-preset/@react-native/babel-plugin-codegen/@react-native/codegen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "conventional-changelog-writer/meow/read-pkg-up/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -3948,61 +3832,13 @@
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/import-fresh": ["import-fresh@2.0.0", "", { "dependencies": { "caller-path": "^2.0.0", "resolve-from": "^3.0.0" } }, "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
 
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker/metro-minify-terser": ["metro-minify-terser@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/import-fresh": ["import-fresh@2.0.0", "", { "dependencies": { "caller-path": "^2.0.0", "resolve-from": "^3.0.0" } }, "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker/metro-minify-terser": ["metro-minify-terser@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/import-fresh": ["import-fresh@2.0.0", "", { "dependencies": { "caller-path": "^2.0.0", "resolve-from": "^3.0.0" } }, "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker/metro-minify-terser": ["metro-minify-terser@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/@react-native/dev-middleware/open/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/import-fresh": ["import-fresh@2.0.0", "", { "dependencies": { "caller-path": "^2.0.0", "resolve-from": "^3.0.0" } }, "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/metro-transform-worker/metro-minify-terser": ["metro-minify-terser@0.83.1", "", { "dependencies": { "flow-enums-runtime": "^0.0.6", "terser": "^5.15.0" } }, "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "@react-native-ai/example/react-native/@react-native/community-cli-plugin/metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "conventional-changelog-writer/meow/read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
@@ -4047,22 +3883,6 @@
     "git-semver-tags/meow/read-pkg-up/read-pkg/normalize-package-data/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
     "git-semver-tags/meow/read-pkg-up/read-pkg/normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/import-fresh/resolve-from": ["resolve-from@3.0.0", "", {}, "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw=="],
-
-    "@react-native-ai/apple/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/import-fresh/resolve-from": ["resolve-from@3.0.0", "", {}, "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw=="],
-
-    "@react-native-ai/dev-tools/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/import-fresh/resolve-from": ["resolve-from@3.0.0", "", {}, "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw=="],
-
-    "@react-native-ai/llama/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/import-fresh/resolve-from": ["resolve-from@3.0.0", "", {}, "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw=="],
-
-    "@react-native-ai/mlc/react-native/@react-native/community-cli-plugin/metro-config/cosmiconfig/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "conventional-changelog-writer/meow/read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/packages/apple-llm/README.md
+++ b/packages/apple-llm/README.md
@@ -21,21 +21,6 @@ const answer = await generateText({
 })
 ```
 
-```ts
-const summarizerModel = apple()
-
-const model = apple({
-  context: {
-    summarizeHistory: {
-      threshold: 5000,
-      model: summarizerModel,
-    },
-    rollingWindowMessages: 10,
-    dropCompletedToolCalls: true,
-  },
-})
-```
-
 ## Features
 
 - ✅ Text generation with Apple Foundation Models
@@ -44,7 +29,6 @@ const model = apple({
 - ✅ Private Cloud Compute language model selection on iOS 27+
 - ✅ Structured outputs
 - ✅ Tool calling
-- ✅ History management helpers for summarization, rolling windows, and completed tool-call pruning
 - ✅ Vision OCR and barcode built-in tools on iOS 27+
 - ✅ Streaming
 - ✅ Image Playground generation through the AI SDK image API

--- a/packages/apple-llm/README.md
+++ b/packages/apple-llm/README.md
@@ -21,6 +21,15 @@ const answer = await generateText({
 })
 ```
 
+```ts
+const summarizerModel = apple()
+
+const model = apple()
+  .summarizeHistory(5000, summarizerModel)
+  .rollingWindow(10)
+  .droppingCompletedToolCalls()
+```
+
 ## Features
 
 - ✅ Text generation with Apple Foundation Models
@@ -29,6 +38,7 @@ const answer = await generateText({
 - ✅ Private Cloud Compute language model selection on iOS 27+
 - ✅ Structured outputs
 - ✅ Tool calling
+- ✅ History management helpers for summarization, rolling windows, and completed tool-call pruning
 - ✅ Vision OCR and barcode built-in tools on iOS 27+
 - ✅ Streaming
 - ✅ Image Playground generation through the AI SDK image API

--- a/packages/apple-llm/README.md
+++ b/packages/apple-llm/README.md
@@ -24,10 +24,16 @@ const answer = await generateText({
 ```ts
 const summarizerModel = apple()
 
-const model = apple()
-  .summarizeHistory(5000, summarizerModel)
-  .rollingWindow(10)
-  .droppingCompletedToolCalls()
+const model = apple({
+  context: {
+    summarizeHistory: {
+      threshold: 5000,
+      model: summarizerModel,
+    },
+    rollingWindowMessages: 10,
+    dropCompletedToolCalls: true,
+  },
+})
 ```
 
 ## Features

--- a/packages/apple-llm/README.md
+++ b/packages/apple-llm/README.md
@@ -21,6 +21,9 @@ const answer = await generateText({
 })
 ```
 
+For reusable history utilities such as summarization, rolling windows, and
+completed tool-call pruning, use `@react-native-ai/utils`.
+
 ## Features
 
 - ✅ Text generation with Apple Foundation Models

--- a/packages/apple-llm/README.md
+++ b/packages/apple-llm/README.md
@@ -3,7 +3,10 @@
 A Vercel AI SDK provider for Apple Foundation Models, enabling access to Apple Intelligence in React Native applications.
 
 **Requirements:**
-- iOS 26+
+
+- iOS 26+ for text generation
+- iOS 26.4+ for token counting and Image Playground generation
+- iOS 27+ for image prompts, Private Cloud Compute, and Vision built-in tools
 - Apple Intelligence enabled device
 - Vercel AI SDK v5
 - React Native New Architecture
@@ -14,16 +17,21 @@ import { generateText } from 'ai'
 
 const answer = await generateText({
   model: apple(),
-  prompt: 'What is the meaning of life?'
+  prompt: 'What is the meaning of life?',
 })
 ```
 
 ## Features
 
 - ✅ Text generation with Apple Foundation Models
+- ✅ Image prompts on iOS 27+
+- ✅ Runtime model info and context-size metadata
+- ✅ Private Cloud Compute language model selection on iOS 27+
 - ✅ Structured outputs
 - ✅ Tool calling
+- ✅ Vision OCR and barcode built-in tools on iOS 27+
 - ✅ Streaming
+- ✅ Image Playground generation through the AI SDK image API
 
 ## Documentation
 

--- a/packages/apple-llm/ios/AppleLLM.mm
+++ b/packages/apple-llm/ios/AppleLLM.mm
@@ -115,7 +115,8 @@ using namespace JS::NativeAppleLLM;
     @"topP": options.topP().has_value() ? @(options.topP().value()) : [NSNull null],
     @"topK": options.topK().has_value() ? @(options.topK().value()) : [NSNull null],
     @"schema": options.schema() ?: [NSNull null],
-    @"tools": options.tools() ?: [NSNull null]
+    @"tools": options.tools() ?: [NSNull null],
+    @"providerOptions": options.providerOptions() ?: [NSNull null]
   };
   
   auto callToolBlock = ^(NSString *toolId, NSString *arguments, void (^completion)(id, NSError *)) {
@@ -131,6 +132,19 @@ using namespace JS::NativeAppleLLM;
   [_llm countTokens:text resolve:resolve reject:reject];
 }
 
+- (void)getModelInfo:(NSString *)locale
+               model:(NSString *)model
+             resolve:(nonnull RCTPromiseResolveBlock)resolve
+              reject:(nonnull RCTPromiseRejectBlock)reject {
+  [_llm getModelInfo:locale model:model resolve:resolve reject:reject];
+}
+
+- (void)generateImages:(nonnull NSDictionary *)options
+               resolve:(nonnull RCTPromiseResolveBlock)resolve
+                reject:(nonnull RCTPromiseRejectBlock)reject {
+  [_llm generateImages:options resolve:resolve reject:reject];
+}
+
 - (void)cancelStream:(nonnull NSString *)streamId {
   [_llm cancelStream:streamId];
 }
@@ -144,6 +158,7 @@ using namespace JS::NativeAppleLLM;
     @"topK": options.topK().has_value() ? @(options.topK().value()) : [NSNull null],
     @"schema": options.schema() ?: [NSNull null],
     @"tools": options.tools() ?: [NSNull null],
+    @"providerOptions": options.providerOptions() ?: [NSNull null],
   };
   
   auto callToolBlock = ^(NSString *toolId, NSString *arguments, void (^completion)(id, NSError *)) {

--- a/packages/apple-llm/ios/AppleLLMError.swift
+++ b/packages/apple-llm/ios/AppleLLMError.swift
@@ -29,8 +29,8 @@ enum AppleLLMError: Error, LocalizedError {
       return "Generation error: \(message)"
     case .streamNotFound(let id):
       return "Stream with ID \(id) not found"
-    case .invalidMessage(let role):
-      return "Invalid message role '\(role)'. Supported roles are: system, user, assistant"
+    case .invalidMessage(let message):
+      return "Invalid message: \(message)"
     case .conflictingSamplingMethods:
       return "Cannot specify both topP and topK parameters simultaneously. Please use only one sampling method."
     case .invalidSchema(let message):

--- a/packages/apple-llm/ios/AppleLLMImpl.swift
+++ b/packages/apple-llm/ios/AppleLLMImpl.swift
@@ -434,7 +434,7 @@ public class AppleLLMImpl: NSObject {
       "isAvailable": model.availability == .available,
       "availability": availabilityString(model.availability),
       "supportsLocale": model.supportsLocale(locale),
-      "supportedLanguages": model.supportedLanguages.map { String(describing: $0) }.sorted(),
+      "supportedLanguages": model.supportedLanguages.map(languageIdentifier).sorted(),
       "supportsTokenCounting": false,
       "supportsImagePrompts": false,
       "supportsPrivateCloudCompute": false,
@@ -472,7 +472,7 @@ public class AppleLLMImpl: NSObject {
       "contextSize": model.contextSize,
       "quotaUsage": String(describing: model.quotaUsage),
       "supportsLocale": model.supportsLocale(locale),
-      "supportedLanguages": model.supportedLanguages.map { String(describing: $0) }.sorted(),
+      "supportedLanguages": model.supportedLanguages.map(languageIdentifier).sorted(),
       "supportsTokenCounting": false,
       "supportsImagePrompts": true,
       "supportsPrivateCloudCompute": true,
@@ -484,6 +484,19 @@ public class AppleLLMImpl: NSObject {
 
   private func availabilityString(_ availability: Any) -> String {
     return String(describing: availability)
+  }
+
+  @available(iOS 26, *)
+  private func languageIdentifier(_ language: Locale.Language) -> String {
+    guard let languageCode = language.languageCode?.identifier else {
+      return language.minimalIdentifier
+    }
+
+    guard let region = language.region?.identifier else {
+      return languageCode
+    }
+
+    return "\(languageCode)-\(region)"
   }
 
   @available(iOS 26, *)

--- a/packages/apple-llm/ios/AppleLLMImpl.swift
+++ b/packages/apple-llm/ios/AppleLLMImpl.swift
@@ -758,7 +758,10 @@ public class AppleLLMImpl: NSObject {
       concepts.append(.text(prompt))
     }
 
-    if let files = options["files"] as? [[String: Any]], let firstFile = files.first {
+    if let files = options["files"] as? [[String: Any]], !files.isEmpty {
+      guard files.count == 1, let firstFile = files.first else {
+        throw AppleLLMError.invalidMessage("Image Playground supports at most one source image file")
+      }
       let attachment = try imageAttachmentFromImageModelFile(firstFile)
       let url = try createImageURL(from: attachment)
 

--- a/packages/apple-llm/ios/AppleLLMImpl.swift
+++ b/packages/apple-llm/ios/AppleLLMImpl.swift
@@ -7,10 +7,17 @@
 //
 
 import Foundation
+import ImageIO
 import React
 
 #if canImport(FoundationModels)
 import FoundationModels
+#endif
+#if canImport(ImagePlayground)
+import ImagePlayground
+#endif
+#if compiler(>=6.3) && canImport(Vision)
+import Vision
 #endif
 
 public typealias ToolInvoker = @Sendable (String, String, @escaping (Any?, Error?) -> Void) -> Void
@@ -40,6 +47,7 @@ public class AppleLLMImpl: NSObject {
     reject: @escaping (String, String, Error?) -> Void
   ) {
 #if canImport(FoundationModels)
+#if compiler(>=6.3)
     if #available(iOS 26.4, *) {
       guard SystemLanguageModel.default.availability == .available else {
         reject(
@@ -65,6 +73,102 @@ public class AppleLLMImpl: NSObject {
     let error = AppleLLMError.unsupportedOS
     reject("AppleLLM", error.localizedDescription, error)
 #endif
+#else
+    let error = AppleLLMError.unsupportedOS
+    reject("AppleLLM", error.localizedDescription, error)
+#endif
+  }
+
+  @objc
+  public func getModelInfo(
+    _ localeIdentifier: String?,
+    model requestedModel: String?,
+    resolve: @escaping (Any?) -> Void,
+    reject: @escaping (String, String, Error?) -> Void
+  ) {
+#if canImport(FoundationModels)
+    if #available(iOS 26, *) {
+      let modelName = requestedModel ?? "system"
+      let locale = localeIdentifier.map(Locale.init(identifier:)) ?? Locale.current
+
+      switch modelName {
+      case "system":
+        resolve(modelInfo(for: SystemLanguageModel.default, locale: locale, modelName: modelName))
+      case "private-cloud-compute":
+#if compiler(>=6.3)
+        if #available(iOS 27, *) {
+          let model = PrivateCloudComputeLanguageModel()
+          resolve(modelInfo(for: model, locale: locale, modelName: modelName))
+        } else {
+          rejectWithAppleError(.unsupportedOS, reject: reject)
+        }
+#else
+        rejectWithAppleError(.unsupportedOS, reject: reject)
+#endif
+      default:
+        rejectWithAppleError(.invalidMessage("Unsupported model '\(modelName)'"), reject: reject)
+      }
+    } else {
+      rejectWithAppleError(.unsupportedOS, reject: reject)
+    }
+#else
+    rejectWithAppleError(.unsupportedOS, reject: reject)
+#endif
+  }
+
+  @objc
+  public func generateImages(
+    _ options: [String: Any],
+    resolve: @escaping (Any?) -> Void,
+    reject: @escaping (String, String, Error?) -> Void
+  ) {
+#if canImport(ImagePlayground)
+    if #available(iOS 26.4, *) {
+      Task {
+        do {
+          let creator = try await ImageCreator()
+          let concepts = try Self.createImagePlaygroundConcepts(from: options)
+          let style = Self.createImagePlaygroundStyle(from: options["style"] as? String)
+          let limit = max(1, min(options["n"] as? Int ?? 1, 4))
+          var images: [String] = []
+
+#if compiler(>=6.3)
+          let imageOptions = Self.createImagePlaygroundOptions(from: options)
+          for try await createdImage in creator.images(
+            for: concepts,
+            style: style,
+            options: imageOptions,
+            limit: limit
+          ) {
+            let data = try Self.pngData(from: createdImage.cgImage)
+            images.append(data.base64EncodedString())
+
+            if images.count >= limit {
+              break
+            }
+          }
+#else
+          for try await createdImage in creator.images(for: concepts, style: style, limit: limit) {
+            let data = try Self.pngData(from: createdImage.cgImage)
+            images.append(data.base64EncodedString())
+
+            if images.count >= limit {
+              break
+            }
+          }
+#endif
+
+          resolve(images)
+        } catch {
+          reject("AppleLLM", error.localizedDescription, error)
+        }
+      }
+    } else {
+      rejectWithAppleError(.unsupportedOS, reject: reject)
+    }
+#else
+    rejectWithAppleError(.unsupportedOS, reject: reject)
+#endif
   }
 
   @objc
@@ -84,30 +188,63 @@ public class AppleLLMImpl: NSObject {
 
       Task {
         do {
-          let tools = try self.createTools(from: options, toolInvoker: toolInvoker)
-          let (transcript, userPrompt) = try self.createTranscriptAndPrompt(from: messages, tools: tools)
-          
-          let session = LanguageModelSession.init(
-            model: SystemLanguageModel.default,
-            tools: tools,
-            transcript: transcript
+          let providerOptions = self.createProviderOptions(from: options)
+          let tools = try self.createTools(from: options, providerOptions: providerOptions, toolInvoker: toolInvoker)
+          let (transcript, userPrompt, promptAttachments) = try self.createTranscriptAndPrompt(
+            from: messages,
+            tools: tools
           )
-          
+
+          let session = try self.createSession(providerOptions: providerOptions, tools: tools, transcript: transcript)
+
           let generationOptions = try self.createGenerationOptions(from: options)
           let generationSchema = try self.createGenerationSchema(from: options)
 
           do {
-            if let generationSchema {
-              let response = try await session.respond(
-                to: userPrompt,
-                schema: generationSchema,
-                includeSchemaInPrompt: true,
-                options: generationOptions
-              )
-              resolve(response.toModelMessages())
+            if promptAttachments.isEmpty {
+              if let generationSchema {
+                let response = try await session.respond(
+                  to: userPrompt,
+                  schema: generationSchema,
+                  includeSchemaInPrompt: true,
+                  options: generationOptions
+                )
+                resolve(response.toModelMessages())
+              } else {
+                let response = try await session.respond(to: userPrompt, options: generationOptions)
+                resolve(response.toModelMessages())
+              }
             } else {
-              let response = try await session.respond(to: userPrompt, options: generationOptions)
-              resolve(response.toModelMessages())
+#if compiler(>=6.3)
+              if #available(iOS 27, *) {
+                let attachments = try self.createImageAttachments(from: promptAttachments)
+                if let generationSchema {
+                  let response = try await session.respond(
+                    schema: generationSchema,
+                    includeSchemaInPrompt: true,
+                    options: generationOptions
+                  ) {
+                    userPrompt
+                    for attachment in attachments {
+                      attachment
+                    }
+                  }
+                  resolve(response.toModelMessages())
+                } else {
+                  let response = try await session.respond(options: generationOptions) {
+                    userPrompt
+                    for attachment in attachments {
+                      attachment
+                    }
+                  }
+                  resolve(response.toModelMessages())
+                }
+              } else {
+                throw AppleLLMError.unsupportedOS
+              }
+#else
+              throw AppleLLMError.unsupportedOS
+#endif
             }
           } catch {
             if let appleError = self.mapToAppleLLMError(error, includeGenerationFallback: true) {
@@ -151,34 +288,71 @@ public class AppleLLMImpl: NSObject {
 
       let task = Task {
         do {
-          let tools = try self.createTools(from: options, toolInvoker: toolInvoker)
-          let (transcript, userPrompt) = try self.createTranscriptAndPrompt(from: messages, tools: tools)
-          
-          let session = LanguageModelSession.init(
-            model: SystemLanguageModel.default,
-            tools: tools,
-            transcript: transcript
+          let providerOptions = self.createProviderOptions(from: options)
+          let tools = try self.createTools(from: options, providerOptions: providerOptions, toolInvoker: toolInvoker)
+          let (transcript, userPrompt, promptAttachments) = try self.createTranscriptAndPrompt(
+            from: messages,
+            tools: tools
           )
-          
+
+          let session = try self.createSession(providerOptions: providerOptions, tools: tools, transcript: transcript)
+
           let generationOptions = try self.createGenerationOptions(from: options)
           let generationSchema = try self.createGenerationSchema(from: options)
 
           do {
-            if let generationSchema {
-              let responseStream = session.streamResponse(
-                to: userPrompt,
-                schema: generationSchema,
-                includeSchemaInPrompt: true,
-                options: generationOptions
-              )
-              for try await chunk in responseStream {
-                onUpdate(streamId, String(describing: chunk.content))
+            if promptAttachments.isEmpty {
+              if let generationSchema {
+                let responseStream = session.streamResponse(
+                  to: userPrompt,
+                  schema: generationSchema,
+                  includeSchemaInPrompt: true,
+                  options: generationOptions
+                )
+                for try await chunk in responseStream {
+                  onUpdate(streamId, String(describing: chunk.content))
+                }
+              } else {
+                let responseStream = session.streamResponse(to: userPrompt, options: generationOptions)
+                for try await chunk in responseStream {
+                  onUpdate(streamId, chunk.content)
+                }
               }
             } else {
-              let responseStream = session.streamResponse(to: userPrompt, options: generationOptions)
-              for try await chunk in responseStream {
-                onUpdate(streamId, chunk.content)
+#if compiler(>=6.3)
+              if #available(iOS 27, *) {
+                let attachments = try self.createImageAttachments(from: promptAttachments)
+                if let generationSchema {
+                  let responseStream = session.streamResponse(
+                    schema: generationSchema,
+                    includeSchemaInPrompt: true,
+                    options: generationOptions
+                  ) {
+                    userPrompt
+                    for attachment in attachments {
+                      attachment
+                    }
+                  }
+                  for try await chunk in responseStream {
+                    onUpdate(streamId, String(describing: chunk.content))
+                  }
+                } else {
+                  let responseStream = session.streamResponse(options: generationOptions) {
+                    userPrompt
+                    for attachment in attachments {
+                      attachment
+                    }
+                  }
+                  for try await chunk in responseStream {
+                    onUpdate(streamId, chunk.content)
+                  }
+                }
+              } else {
+                throw AppleLLMError.unsupportedOS
               }
+#else
+              throw AppleLLMError.unsupportedOS
+#endif
             }
 
             if !Task.isCancelled {
@@ -254,6 +428,105 @@ public class AppleLLMImpl: NSObject {
 
 #if canImport(FoundationModels)
   @available(iOS 26, *)
+  private func modelInfo(for model: SystemLanguageModel, locale: Locale, modelName: String) -> [String: Any] {
+    var info: [String: Any] = [
+      "model": modelName,
+      "isAvailable": model.availability == .available,
+      "availability": availabilityString(model.availability),
+      "supportsLocale": model.supportsLocale(locale),
+      "supportedLanguages": model.supportedLanguages.map { String(describing: $0) }.sorted(),
+      "supportsTokenCounting": false,
+      "supportsImagePrompts": false,
+      "supportsPrivateCloudCompute": false,
+      "supportsDynamicProfiles": false,
+      "supportsVisionTools": false,
+    ]
+
+#if compiler(>=6.3)
+    if #available(iOS 26.4, *) {
+      info["contextSize"] = model.contextSize
+      info["supportsTokenCounting"] = true
+    }
+
+    if #available(iOS 27, *) {
+      info["supportsImagePrompts"] = true
+      info["supportsDynamicProfiles"] = true
+      info["supportsVisionTools"] = true
+    }
+#endif
+
+    return info
+  }
+
+#if compiler(>=6.3)
+  @available(iOS 27, *)
+  private func modelInfo(
+    for model: PrivateCloudComputeLanguageModel,
+    locale: Locale,
+    modelName: String
+  ) -> [String: Any] {
+    return [
+      "model": modelName,
+      "isAvailable": model.availability == .available,
+      "availability": availabilityString(model.availability),
+      "contextSize": model.contextSize,
+      "quotaUsage": String(describing: model.quotaUsage),
+      "supportsLocale": model.supportsLocale(locale),
+      "supportedLanguages": model.supportedLanguages.map { String(describing: $0) }.sorted(),
+      "supportsTokenCounting": false,
+      "supportsImagePrompts": true,
+      "supportsPrivateCloudCompute": true,
+      "supportsDynamicProfiles": true,
+      "supportsVisionTools": true,
+    ]
+  }
+#endif
+
+  private func availabilityString(_ availability: Any) -> String {
+    return String(describing: availability)
+  }
+
+  @available(iOS 26, *)
+  private func createProviderOptions(from options: [String: Any]) -> [String: Any] {
+    guard let providerOptions = options["providerOptions"] as? [String: Any] else {
+      return [:]
+    }
+
+    return providerOptions
+  }
+
+  @available(iOS 26, *)
+  private func createSession(
+    providerOptions: [String: Any],
+    tools: [any Tool],
+    transcript: Transcript
+  ) throws -> LanguageModelSession {
+    let modelName = providerOptions["model"] as? String ?? "system"
+
+    switch modelName {
+    case "system":
+      return LanguageModelSession(
+        model: SystemLanguageModel.default,
+        tools: tools,
+        transcript: transcript
+      )
+    case "private-cloud-compute":
+#if compiler(>=6.3)
+      if #available(iOS 27, *) {
+        return LanguageModelSession(
+          model: PrivateCloudComputeLanguageModel(),
+          tools: tools,
+          transcript: transcript
+        )
+      }
+#endif
+      throw AppleLLMError.unsupportedOS
+    default:
+      throw AppleLLMError.invalidMessage("Unsupported model '\(modelName)'")
+    }
+  }
+
+  @available(iOS 26, *)
   private func mapKnownAppleLLMError(_ error: Error) -> AppleLLMError? {
     if let appleError = error as? AppleLLMError {
       return appleError
@@ -304,9 +577,13 @@ public class AppleLLMImpl: NSObject {
   }
 
   @available(iOS 26, *)
-  private func createTools(from options: [String: Any], toolInvoker: @escaping ToolInvoker) throws -> [any Tool] {
+  private func createTools(
+    from options: [String: Any],
+    providerOptions: [String: Any],
+    toolInvoker: @escaping ToolInvoker
+  ) throws -> [any Tool] {
     guard let toolsDict = options["tools"] as? [[String: Any]] else {
-      return []
+      return try createBuiltInTools(from: providerOptions)
     }
     
     var tools: [any Tool] = []
@@ -328,15 +605,41 @@ public class AppleLLMImpl: NSObject {
       )
       tools.append(tool)
     }
+
+    tools.append(contentsOf: try createBuiltInTools(from: providerOptions))
     
     return tools
   }
-  
-  // TODO:
-  //   • Investigate assetIDs parameter usage in Transcript.Response
-  //   • Implement tool calling support
+
   @available(iOS 26, *)
-  private func createTranscriptAndPrompt(from messages: [[String: Any]], tools: [any Tool]) throws -> (Transcript, String) {
+  private func createBuiltInTools(from providerOptions: [String: Any]) throws -> [any Tool] {
+    guard let toolNames = providerOptions["builtInTools"] as? [String], !toolNames.isEmpty else {
+      return []
+    }
+
+#if compiler(>=6.3) && canImport(Vision)
+    if #available(iOS 27, *) {
+      return try toolNames.map { toolName in
+        switch toolName {
+        case "ocr":
+          return OCRTool()
+        case "barcode":
+          return BarcodeReaderTool()
+        default:
+          throw AppleLLMError.invalidMessage("Unsupported built-in tool '\(toolName)'")
+        }
+      }
+    }
+#endif
+
+    throw AppleLLMError.unsupportedOS
+  }
+  
+  @available(iOS 26, *)
+  private func createTranscriptAndPrompt(
+    from messages: [[String: Any]],
+    tools: [any Tool]
+  ) throws -> (Transcript, String, [[String: Any]]) {
     guard !messages.isEmpty else {
       throw AppleLLMError.invalidMessage("Messages array cannot be empty")
     }
@@ -347,6 +650,8 @@ public class AppleLLMImpl: NSObject {
           lastRole == "user" else {
       throw AppleLLMError.invalidMessage("Last message must be from user role")
     }
+
+    let promptAttachments = lastMessage["attachments"] as? [[String: Any]] ?? []
     
     var entries: [Transcript.Entry] = []
     
@@ -356,6 +661,10 @@ public class AppleLLMImpl: NSObject {
       guard let role = message["role"] as? String,
             let content = message["content"] as? String else {
         throw AppleLLMError.invalidMessage("Message must have role and content")
+      }
+
+      if let attachments = message["attachments"] as? [[String: Any]], !attachments.isEmpty {
+        throw AppleLLMError.invalidMessage("Image attachments are only supported on the final user prompt")
       }
       
       let segment = Transcript.Segment.text(
@@ -376,11 +685,194 @@ public class AppleLLMImpl: NSObject {
         let response = Transcript.Response(assetIDs: [], segments: [segment])
         entries.append(.response(response))
       default:
-        throw AppleLLMError.invalidMessage(role)
+        throw AppleLLMError.invalidMessage("Unsupported role '\(role)'. Supported roles are: system, user, assistant")
       }
     }
     
-    return (Transcript(entries: entries), userPrompt)
+    return (Transcript(entries: entries), userPrompt, promptAttachments)
+  }
+
+#if compiler(>=6.3)
+  @available(iOS 27, *)
+  private func createImageAttachments(
+    from attachments: [[String: Any]]
+  ) throws -> [Attachment<ImageAttachmentContent>] {
+    try attachments.map { attachment in
+      guard let type = attachment["type"] as? String, type == "image" else {
+        throw AppleLLMError.invalidMessage("Unsupported attachment type")
+      }
+
+      let imageURL = try Self.createImageURL(from: attachment)
+      var imageAttachment = Attachment(imageURL: imageURL)
+
+      if let label = attachment["label"] as? String, !label.isEmpty {
+        imageAttachment = imageAttachment.label(label)
+      }
+
+      return imageAttachment
+    }
+  }
+#endif
+
+  private static func createImageURL(from attachment: [String: Any]) throws -> URL {
+    if let urlString = attachment["url"] as? String, !urlString.isEmpty {
+      let url = urlString.hasPrefix("/")
+        ? URL(fileURLWithPath: urlString)
+        : URL(string: urlString)
+
+      guard let url, url.isFileURL else {
+        throw AppleLLMError.invalidMessage("Image attachment URLs must be local file URLs")
+      }
+
+      return url
+    }
+
+    guard let dataValue = attachment["data"] as? String, !dataValue.isEmpty else {
+      throw AppleLLMError.invalidMessage("Image attachment must include url or data")
+    }
+
+    let mediaType = attachment["mediaType"] as? String
+    let base64Payload = dataValue.contains(",")
+      ? String(dataValue.split(separator: ",", maxSplits: 1, omittingEmptySubsequences: false).last ?? "")
+      : dataValue
+
+    guard let imageData = Data(base64Encoded: base64Payload) else {
+      throw AppleLLMError.invalidMessage("Image attachment data must be base64 encoded")
+    }
+
+    let fileExtension = Self.fileExtension(forImageMediaType: mediaType)
+    let fileURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension(fileExtension)
+
+    try imageData.write(to: fileURL, options: .atomic)
+    return fileURL
+  }
+
+#if canImport(ImagePlayground)
+  @available(iOS 26.4, *)
+  private static func createImagePlaygroundConcepts(from options: [String: Any]) throws -> [ImagePlaygroundConcept] {
+    var concepts: [ImagePlaygroundConcept] = []
+
+    if let prompt = options["prompt"] as? String, !prompt.isEmpty {
+      concepts.append(.text(prompt))
+    }
+
+    if let files = options["files"] as? [[String: Any]], let firstFile = files.first {
+      let attachment = try imageAttachmentFromImageModelFile(firstFile)
+      let url = try createImageURL(from: attachment)
+
+      guard let imageConcept = ImagePlaygroundConcept.image(url) else {
+        throw AppleLLMError.invalidMessage("Image Playground file must resolve to a local image")
+      }
+
+      concepts.append(imageConcept)
+    }
+
+    guard !concepts.isEmpty else {
+      throw AppleLLMError.invalidMessage("Image Playground generation requires a prompt or image file")
+    }
+
+    return concepts
+  }
+
+  private static func imageAttachmentFromImageModelFile(_ file: [String: Any]) throws -> [String: Any] {
+    var attachment: [String: Any] = [
+      "type": "image",
+      "mediaType": file["mediaType"] as? String ?? "image/png",
+    ]
+
+    if let data = file["data"] as? String {
+      if data.hasPrefix("file://") || data.hasPrefix("/") {
+        attachment["url"] = data
+      } else {
+        attachment["data"] = data
+      }
+    } else {
+      throw AppleLLMError.invalidMessage("Image Playground file data must be a string")
+    }
+
+    return attachment
+  }
+
+  @available(iOS 26.4, *)
+  private static func createImagePlaygroundStyle(from style: String?) -> ImagePlaygroundStyle {
+    switch style {
+    case "animation":
+      return .animation
+    case "illustration":
+      return .illustration
+    case "sketch":
+      return .sketch
+#if compiler(>=6.3)
+    case "any":
+      if #available(iOS 27, *) {
+        return .any
+      }
+      return .illustration
+    case "emoji":
+      if #available(iOS 27, *) {
+        return .emoji
+      }
+      return .illustration
+    case "externalProvider":
+      if #available(iOS 27, *) {
+        return .externalProvider
+      }
+      return .illustration
+#endif
+    default:
+      return .illustration
+    }
+  }
+
+#if compiler(>=6.3)
+  @available(iOS 26.4, *)
+  private static func createImagePlaygroundOptions(from options: [String: Any]) -> ImagePlaygroundOptions {
+    var imageOptions = ImagePlaygroundOptions()
+
+    switch options["personalization"] as? String {
+    case "disabled":
+      imageOptions.personalization = .disabled
+    case "enabled":
+      imageOptions.personalization = .enabled
+    default:
+      imageOptions.personalization = .automatic
+    }
+
+    return imageOptions
+  }
+#endif
+
+  private static func pngData(from image: CGImage) throws -> Data {
+    let data = NSMutableData()
+    guard let destination = CGImageDestinationCreateWithData(data, "public.png" as CFString, 1, nil) else {
+      throw AppleLLMError.generationError("Failed to create PNG image destination")
+    }
+
+    CGImageDestinationAddImage(destination, image, nil)
+
+    guard CGImageDestinationFinalize(destination) else {
+      throw AppleLLMError.generationError("Failed to encode generated image")
+    }
+
+    return data as Data
+  }
+#endif
+
+  private static func fileExtension(forImageMediaType mediaType: String?) -> String {
+    switch mediaType?.lowercased() {
+    case "image/jpeg", "image/jpg":
+      return "jpg"
+    case "image/heic":
+      return "heic"
+    case "image/webp":
+      return "webp"
+    case "image/gif":
+      return "gif"
+    default:
+      return "png"
+    }
   }
   
   @available(iOS 26, *)

--- a/packages/apple-llm/ios/AppleLLMImpl.swift
+++ b/packages/apple-llm/ios/AppleLLMImpl.swift
@@ -99,8 +99,12 @@ public class AppleLLMImpl: NSObject {
         if #available(iOS 27, *) {
           let model = PrivateCloudComputeLanguageModel()
           Task {
-            let info = await modelInfo(for: model, locale: locale, modelName: modelName)
+            do {
+              let info = try await modelInfo(for: model, locale: locale, modelName: modelName)
             resolve(info)
+            } catch {
+              reject("AppleLLM", error.localizedDescription, error)
+            }
           }
         } else {
           rejectWithAppleError(.unsupportedOS, reject: reject)
@@ -467,8 +471,8 @@ public class AppleLLMImpl: NSObject {
     for model: PrivateCloudComputeLanguageModel,
     locale: Locale,
     modelName: String
-  ) async -> [String: Any] {
-    let contextSize = await model.contextSize
+  ) async throws -> [String: Any] {
+    let contextSize = try await model.contextSize
     return [
       "model": modelName,
       "isAvailable": model.availability == .available,

--- a/packages/apple-llm/ios/AppleLLMImpl.swift
+++ b/packages/apple-llm/ios/AppleLLMImpl.swift
@@ -24,6 +24,10 @@ public typealias ToolInvoker = @Sendable (String, String, @escaping (Any?, Error
 
 @objc
 public class AppleLLMImpl: NSObject {
+  private struct ImageURL {
+    let url: URL
+    let needsCleanup: Bool
+  }
   
   private var streamTasks: [String: Task<Void, Never>] = [:]
   
@@ -134,7 +138,10 @@ public class AppleLLMImpl: NSObject {
       Task {
         do {
           let creator = try await ImageCreator()
-          let concepts = try Self.createImagePlaygroundConcepts(from: options)
+          let playgroundConcepts = try Self.createImagePlaygroundConcepts(from: options)
+          defer {
+            Self.removeTemporaryFiles(playgroundConcepts.temporaryFileURLs)
+          }
           let style = Self.createImagePlaygroundStyle(from: options["style"] as? String)
           let limit = max(1, min(options["n"] as? Int ?? 1, 4))
           var images: [String] = []
@@ -142,7 +149,7 @@ public class AppleLLMImpl: NSObject {
 #if compiler(>=6.3)
           let imageOptions = Self.createImagePlaygroundOptions(from: options)
           for try await createdImage in creator.images(
-            for: concepts,
+            for: playgroundConcepts.values,
             style: style,
             options: imageOptions,
             limit: limit
@@ -155,7 +162,11 @@ public class AppleLLMImpl: NSObject {
             }
           }
 #else
-          for try await createdImage in creator.images(for: concepts, style: style, limit: limit) {
+          for try await createdImage in creator.images(
+            for: playgroundConcepts.values,
+            style: style,
+            limit: limit
+          ) {
             let data = try Self.pngData(from: createdImage.cgImage)
             images.append(data.base64EncodedString())
 
@@ -224,7 +235,10 @@ public class AppleLLMImpl: NSObject {
             } else {
 #if compiler(>=6.3)
               if #available(iOS 27, *) {
-                let attachments = try self.createImageAttachments(from: promptAttachments)
+                let preparedAttachments = try self.createImageAttachments(from: promptAttachments)
+                defer {
+                  Self.removeTemporaryFiles(preparedAttachments.temporaryFileURLs)
+                }
                 if let generationSchema {
                   let response = try await session.respond(
                     schema: generationSchema,
@@ -232,7 +246,7 @@ public class AppleLLMImpl: NSObject {
                     options: generationOptions
                   ) {
                     userPrompt
-                    for attachment in attachments {
+                    for attachment in preparedAttachments.values {
                       attachment
                     }
                   }
@@ -240,7 +254,7 @@ public class AppleLLMImpl: NSObject {
                 } else {
                   let response = try await session.respond(options: generationOptions) {
                     userPrompt
-                    for attachment in attachments {
+                    for attachment in preparedAttachments.values {
                       attachment
                     }
                   }
@@ -328,7 +342,10 @@ public class AppleLLMImpl: NSObject {
             } else {
 #if compiler(>=6.3)
               if #available(iOS 27, *) {
-                let attachments = try self.createImageAttachments(from: promptAttachments)
+                let preparedAttachments = try self.createImageAttachments(from: promptAttachments)
+                defer {
+                  Self.removeTemporaryFiles(preparedAttachments.temporaryFileURLs)
+                }
                 if let generationSchema {
                   let responseStream = session.streamResponse(
                     schema: generationSchema,
@@ -336,7 +353,7 @@ public class AppleLLMImpl: NSObject {
                     options: generationOptions
                   ) {
                     userPrompt
-                    for attachment in attachments {
+                    for attachment in preparedAttachments.values {
                       attachment
                     }
                   }
@@ -346,7 +363,7 @@ public class AppleLLMImpl: NSObject {
                 } else {
                   let responseStream = session.streamResponse(options: generationOptions) {
                     userPrompt
-                    for attachment in attachments {
+                    for attachment in preparedAttachments.values {
                       attachment
                     }
                   }
@@ -436,15 +453,15 @@ public class AppleLLMImpl: NSObject {
 #if canImport(FoundationModels)
   @available(iOS 26, *)
   private func modelInfo(for model: SystemLanguageModel, locale: Locale, modelName: String) -> [String: Any] {
+    let isAvailable = model.availability == .available
     var info: [String: Any] = [
       "model": modelName,
-      "isAvailable": model.availability == .available,
-      "availability": availabilityString(model.availability),
+      "isAvailable": isAvailable,
+      "availability": isAvailable ? "available" : "unavailable",
       "supportsLocale": model.supportsLocale(locale),
       "supportedLanguages": model.supportedLanguages.map(languageIdentifier).sorted(),
       "supportsTokenCounting": false,
       "supportsImagePrompts": false,
-      "supportsPrivateCloudCompute": false,
       "supportsDynamicProfiles": false,
       "supportsVisionTools": false,
     ]
@@ -473,26 +490,21 @@ public class AppleLLMImpl: NSObject {
     modelName: String
   ) async throws -> [String: Any] {
     let contextSize = try await model.contextSize
+    let isAvailable = model.availability == .available
     return [
       "model": modelName,
-      "isAvailable": model.availability == .available,
-      "availability": availabilityString(model.availability),
+      "isAvailable": isAvailable,
+      "availability": isAvailable ? "available" : "unavailable",
       "contextSize": contextSize,
-      "quotaUsage": String(describing: model.quotaUsage),
       "supportsLocale": model.supportsLocale(locale),
       "supportedLanguages": model.supportedLanguages.map(languageIdentifier).sorted(),
       "supportsTokenCounting": false,
       "supportsImagePrompts": true,
-      "supportsPrivateCloudCompute": true,
       "supportsDynamicProfiles": true,
       "supportsVisionTools": true,
     ]
   }
 #endif
-
-  private func availabilityString(_ availability: Any) -> String {
-    return String(describing: availability)
-  }
 
   @available(iOS 26, *)
   private func languageIdentifier(_ language: Locale.Language) -> String {
@@ -717,25 +729,39 @@ public class AppleLLMImpl: NSObject {
   @available(iOS 27, *)
   private func createImageAttachments(
     from attachments: [[String: Any]]
-  ) throws -> [Attachment<ImageAttachmentContent>] {
-    try attachments.map { attachment in
-      guard let type = attachment["type"] as? String, type == "image" else {
-        throw AppleLLMError.invalidMessage("Unsupported attachment type")
+  ) throws -> (values: [Attachment<ImageAttachmentContent>], temporaryFileURLs: [URL]) {
+    var imageAttachments: [Attachment<ImageAttachmentContent>] = []
+    var temporaryFileURLs: [URL] = []
+
+    do {
+      for attachment in attachments {
+        guard let type = attachment["type"] as? String, type == "image" else {
+          throw AppleLLMError.invalidMessage("Unsupported attachment type")
+        }
+
+        let imageURL = try Self.createImageURL(from: attachment)
+        if imageURL.needsCleanup {
+          temporaryFileURLs.append(imageURL.url)
+        }
+
+        var imageAttachment = Attachment(imageURL: imageURL.url)
+
+        if let label = attachment["label"] as? String, !label.isEmpty {
+          imageAttachment = imageAttachment.label(label)
+        }
+
+        imageAttachments.append(imageAttachment)
       }
-
-      let imageURL = try Self.createImageURL(from: attachment)
-      var imageAttachment = Attachment(imageURL: imageURL)
-
-      if let label = attachment["label"] as? String, !label.isEmpty {
-        imageAttachment = imageAttachment.label(label)
-      }
-
-      return imageAttachment
+    } catch {
+      Self.removeTemporaryFiles(temporaryFileURLs)
+      throw error
     }
+
+    return (imageAttachments, temporaryFileURLs)
   }
 #endif
 
-  private static func createImageURL(from attachment: [String: Any]) throws -> URL {
+  private static func createImageURL(from attachment: [String: Any]) throws -> ImageURL {
     if let urlString = attachment["url"] as? String, !urlString.isEmpty {
       let url = urlString.hasPrefix("/")
         ? URL(fileURLWithPath: urlString)
@@ -745,7 +771,7 @@ public class AppleLLMImpl: NSObject {
         throw AppleLLMError.invalidMessage("Image attachment URLs must be local file URLs")
       }
 
-      return url
+      return ImageURL(url: url, needsCleanup: false)
     }
 
     guard let dataValue = attachment["data"] as? String, !dataValue.isEmpty else {
@@ -767,37 +793,55 @@ public class AppleLLMImpl: NSObject {
       .appendingPathExtension(fileExtension)
 
     try imageData.write(to: fileURL, options: .atomic)
-    return fileURL
+    return ImageURL(url: fileURL, needsCleanup: true)
+  }
+
+  private static func removeTemporaryFiles(_ urls: [URL]) {
+    for url in urls {
+      try? FileManager.default.removeItem(at: url)
+    }
   }
 
 #if canImport(ImagePlayground)
   @available(iOS 26.4, *)
-  private static func createImagePlaygroundConcepts(from options: [String: Any]) throws -> [ImagePlaygroundConcept] {
+  private static func createImagePlaygroundConcepts(
+    from options: [String: Any]
+  ) throws -> (values: [ImagePlaygroundConcept], temporaryFileURLs: [URL]) {
     var concepts: [ImagePlaygroundConcept] = []
+    var temporaryFileURLs: [URL] = []
 
     if let prompt = options["prompt"] as? String, !prompt.isEmpty {
       concepts.append(.text(prompt))
     }
 
-    if let files = options["files"] as? [[String: Any]], !files.isEmpty {
-      guard files.count == 1, let firstFile = files.first else {
-        throw AppleLLMError.invalidMessage("Image Playground supports at most one source image file")
-      }
-      let attachment = try imageAttachmentFromImageModelFile(firstFile)
-      let url = try createImageURL(from: attachment)
+    do {
+      if let files = options["files"] as? [[String: Any]], !files.isEmpty {
+        guard files.count == 1, let firstFile = files.first else {
+          throw AppleLLMError.invalidMessage("Image Playground supports at most one source image file")
+        }
+        let attachment = try imageAttachmentFromImageModelFile(firstFile)
+        let imageURL = try createImageURL(from: attachment)
 
-      guard let imageConcept = ImagePlaygroundConcept.image(url) else {
-        throw AppleLLMError.invalidMessage("Image Playground file must resolve to a local image")
-      }
+        if imageURL.needsCleanup {
+          temporaryFileURLs.append(imageURL.url)
+        }
 
-      concepts.append(imageConcept)
+        guard let imageConcept = ImagePlaygroundConcept.image(imageURL.url) else {
+          throw AppleLLMError.invalidMessage("Image Playground file must resolve to a local image")
+        }
+
+        concepts.append(imageConcept)
+      }
+    } catch {
+      removeTemporaryFiles(temporaryFileURLs)
+      throw error
     }
 
     guard !concepts.isEmpty else {
       throw AppleLLMError.invalidMessage("Image Playground generation requires a prompt or image file")
     }
 
-    return concepts
+    return (concepts, temporaryFileURLs)
   }
 
   private static func imageAttachmentFromImageModelFile(_ file: [String: Any]) throws -> [String: Any] {

--- a/packages/apple-llm/ios/AppleLLMImpl.swift
+++ b/packages/apple-llm/ios/AppleLLMImpl.swift
@@ -879,7 +879,7 @@ public class AppleLLMImpl: NSObject {
   private static func fileExtension(forImageMediaType mediaType: String?) -> String {
     switch mediaType?.lowercased() {
     case "image/jpeg", "image/jpg":
-      return "jpg"
+      return "jpeg"
     case "image/heic":
       return "heic"
     case "image/webp":

--- a/packages/apple-llm/ios/AppleLLMImpl.swift
+++ b/packages/apple-llm/ios/AppleLLMImpl.swift
@@ -98,7 +98,10 @@ public class AppleLLMImpl: NSObject {
 #if compiler(>=6.3)
         if #available(iOS 27, *) {
           let model = PrivateCloudComputeLanguageModel()
-          resolve(modelInfo(for: model, locale: locale, modelName: modelName))
+          Task {
+            let info = await modelInfo(for: model, locale: locale, modelName: modelName)
+            resolve(info)
+          }
         } else {
           rejectWithAppleError(.unsupportedOS, reject: reject)
         }
@@ -464,12 +467,13 @@ public class AppleLLMImpl: NSObject {
     for model: PrivateCloudComputeLanguageModel,
     locale: Locale,
     modelName: String
-  ) -> [String: Any] {
+  ) async -> [String: Any] {
+    let contextSize = await model.contextSize
     return [
       "model": modelName,
       "isAvailable": model.availability == .available,
       "availability": availabilityString(model.availability),
-      "contextSize": model.contextSize,
+      "contextSize": contextSize,
       "quotaUsage": String(describing: model.quotaUsage),
       "supportsLocale": model.supportsLocale(locale),
       "supportedLanguages": model.supportedLanguages.map(languageIdentifier).sorted(),

--- a/packages/apple-llm/src/AppleFoundationModels.ts
+++ b/packages/apple-llm/src/AppleFoundationModels.ts
@@ -1,3 +1,4 @@
+import type { AppleLanguageModelId } from './ai-sdk'
 import NativeAppleLLM, {
   type AppleGenerationOptions,
   type AppleMessage,
@@ -13,9 +14,16 @@ const nativeAppleLLM = NativeAppleLLM as Spec & {
   generateImages?: (options: object) => Promise<string[]>
 }
 
-const AppleFoundationModels: Spec = {
+type AppleFoundationModelsSpec = Omit<Spec, 'getModelInfo'> & {
+  getModelInfo(
+    locale?: string,
+    model?: AppleLanguageModelId
+  ): ReturnType<Spec['getModelInfo']>
+}
+
+const AppleFoundationModels: AppleFoundationModelsSpec = {
   isAvailable: () => NativeAppleLLM.isAvailable(),
-  getModelInfo: (locale?: string, model?: string) => {
+  getModelInfo: (locale?: string, model?: AppleLanguageModelId) => {
     if (typeof nativeAppleLLM.getModelInfo !== 'function') {
       return Promise.reject(
         new Error(

--- a/packages/apple-llm/src/AppleFoundationModels.ts
+++ b/packages/apple-llm/src/AppleFoundationModels.ts
@@ -9,16 +9,40 @@ const tokenCountingUnavailableMessage =
 
 const nativeAppleLLM = NativeAppleLLM as Spec & {
   countTokens?: (text: string) => Promise<number>
+  getModelInfo?: (locale?: string, model?: string) => Promise<object>
+  generateImages?: (options: object) => Promise<string[]>
 }
 
 const AppleFoundationModels: Spec = {
   isAvailable: () => NativeAppleLLM.isAvailable(),
+  getModelInfo: (locale?: string, model?: string) => {
+    if (typeof nativeAppleLLM.getModelInfo !== 'function') {
+      return Promise.reject(
+        new Error(
+          'Apple Foundation Models model info is unavailable. Rebuild the native module with getModelInfo support.'
+        )
+      )
+    }
+
+    return nativeAppleLLM.getModelInfo(locale, model)
+  },
   countTokens: (text) => {
     if (typeof nativeAppleLLM.countTokens !== 'function') {
       return Promise.reject(new Error(tokenCountingUnavailableMessage))
     }
 
     return nativeAppleLLM.countTokens(text)
+  },
+  generateImages: (options) => {
+    if (typeof nativeAppleLLM.generateImages !== 'function') {
+      return Promise.reject(
+        new Error(
+          'Apple Image Playground generation is unavailable. Rebuild the native module with generateImages support.'
+        )
+      )
+    }
+
+    return nativeAppleLLM.generateImages(options)
   },
   generateText: (messages: AppleMessage[], options: AppleGenerationOptions) =>
     NativeAppleLLM.generateText(messages, options),

--- a/packages/apple-llm/src/NativeAppleLLM.ts
+++ b/packages/apple-llm/src/NativeAppleLLM.ts
@@ -8,6 +8,7 @@ import type {
 export interface AppleMessage {
   role: 'assistant' | 'system' | 'tool' | 'user'
   content: string
+  attachments?: UnsafeObject[]
 }
 
 export interface AppleGenerationOptions {
@@ -17,6 +18,7 @@ export interface AppleGenerationOptions {
   topK?: number
   schema?: UnsafeObject
   tools?: UnsafeObject
+  providerOptions?: UnsafeObject
 }
 
 export type StreamUpdateEvent = {
@@ -36,7 +38,9 @@ export type StreamErrorEvent = {
 
 export interface Spec extends TurboModule {
   isAvailable(): boolean
+  getModelInfo(locale?: string, model?: string): Promise<UnsafeObject>
   countTokens(text: string): Promise<number>
+  generateImages(options: UnsafeObject): Promise<string[]>
   generateText(
     messages: AppleMessage[],
     options: AppleGenerationOptions

--- a/packages/apple-llm/src/ai-sdk.ts
+++ b/packages/apple-llm/src/ai-sdk.ts
@@ -2,8 +2,11 @@ import type {
   EmbeddingModelV3,
   EmbeddingModelV3CallOptions,
   EmbeddingModelV3Result,
+  ImageModelV3,
+  ImageModelV3CallOptions,
   LanguageModelV3,
   LanguageModelV3CallOptions,
+  LanguageModelV3Message,
   LanguageModelV3FunctionTool,
   LanguageModelV3Prompt,
   LanguageModelV3ProviderTool,
@@ -30,25 +33,299 @@ import NativeAppleUtils from './NativeAppleUtils'
 
 type Tool = LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
 type ToolDefinitionSet = Record<string, FullToolDefinition>
+export type AppleLanguageModelId = 'system' | 'private-cloud-compute'
+export type AppleBuiltInTool = 'ocr' | 'barcode'
+export type AppleImageStyle =
+  | 'animation'
+  | 'any'
+  | 'emoji'
+  | 'externalProvider'
+  | 'illustration'
+  | 'sketch'
+export type AppleImagePersonalization = 'automatic' | 'disabled' | 'enabled'
+
+export interface AppleProviderOptions {
+  model?: AppleLanguageModelId
+  builtInTools?: AppleBuiltInTool[]
+  context?: AppleContextOptions
+  style?: AppleImageStyle
+  personalization?: AppleImagePersonalization
+}
+
+export interface AppleModelInfo {
+  model: AppleLanguageModelId
+  isAvailable: boolean
+  availability: string
+  supportsLocale: boolean
+  supportedLanguages: string[]
+  supportsTokenCounting: boolean
+  supportsImagePrompts: boolean
+  supportsPrivateCloudCompute: boolean
+  supportsDynamicProfiles: boolean
+  supportsVisionTools: boolean
+  contextSize?: number
+  quotaUsage?: string
+}
+
+export interface AppleLanguageModelOptions {
+  model?: AppleLanguageModelId
+  availableTools?: ToolDefinitionSet
+  context?: AppleContextOptions
+}
+
+export interface AppleContextOptions {
+  /**
+   * Keep the first system message and only the last N non-system messages.
+   */
+  rollingWindowMessages?: number
+  /**
+   * Remove completed tool-call/tool-result entries from older context.
+   */
+  dropCompletedToolCalls?: boolean
+}
+
+type AppleMessageAttachment = {
+  type: 'image'
+  mediaType: string
+  data?: string
+  url?: string
+}
+
+type AppleImageModelFile = {
+  mediaType: string
+  data: string
+}
+
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize)
+    binary += String.fromCharCode(...chunk)
+  }
+  return btoa(binary)
+}
+
+function prepareImageAttachment(
+  part: Extract<
+    Extract<
+      LanguageModelV3Prompt[number],
+      { content: unknown[] }
+    >['content'][number],
+    { type: 'file' }
+  >
+): AppleMessageAttachment {
+  const mediaType = part.mediaType.toLowerCase()
+  if (!mediaType.startsWith('image/')) {
+    throw new Error(
+      `Unsupported Apple Foundation Models file type: ${part.mediaType}`
+    )
+  }
+
+  const data = part.data as unknown
+
+  if (data instanceof Uint8Array) {
+    return {
+      type: 'image',
+      mediaType,
+      data: uint8ArrayToBase64(data),
+    }
+  }
+
+  const value =
+    data instanceof URL
+      ? data.toString()
+      : typeof data === 'string'
+        ? data
+        : null
+
+  if (!value) {
+    throw new Error('Unsupported Apple Foundation Models image data')
+  }
+
+  if (value.startsWith('data:')) {
+    return {
+      type: 'image',
+      mediaType,
+      data: value,
+    }
+  }
+
+  return {
+    type: 'image',
+    mediaType,
+    url: value,
+  }
+}
+
+function prepareImageModelFiles(
+  files: ImageModelV3CallOptions['files'] = []
+): AppleImageModelFile[] {
+  return files.map((file) => {
+    if (file.type === 'url') {
+      return {
+        mediaType: 'image/png',
+        data: file.url,
+      }
+    }
+
+    const mediaType = file.mediaType.toLowerCase()
+    if (!mediaType.startsWith('image/')) {
+      throw new Error(
+        `Unsupported Apple Image Playground file type: ${file.mediaType}`
+      )
+    }
+
+    const data = file.data as unknown
+    const normalizedData =
+      data instanceof Uint8Array
+        ? uint8ArrayToBase64(data)
+        : data instanceof URL
+          ? data.toString()
+          : typeof data === 'string'
+            ? data
+            : null
+
+    if (!normalizedData) {
+      throw new Error('Unsupported Apple Image Playground image data')
+    }
+
+    return {
+      mediaType,
+      data: normalizedData,
+    }
+  })
+}
+
+function getAppleProviderOptions(
+  providerOptions: LanguageModelV3CallOptions['providerOptions'] | undefined
+): AppleProviderOptions {
+  return (providerOptions?.apple ?? {}) as AppleProviderOptions
+}
+
+function mergeAppleProviderOptions(
+  defaults: AppleLanguageModelOptions,
+  callOptions: AppleProviderOptions
+): AppleProviderOptions {
+  return {
+    model: callOptions.model ?? defaults.model,
+    builtInTools: callOptions.builtInTools,
+    context: {
+      ...defaults.context,
+      ...callOptions.context,
+    },
+  }
+}
+
+export function trimAppleMessagesForContext(
+  messages: LanguageModelV3Prompt,
+  options: AppleContextOptions = {}
+): LanguageModelV3Prompt {
+  let nextMessages = messages
+
+  if (options.dropCompletedToolCalls) {
+    nextMessages = dropCompletedToolCallMessages(nextMessages)
+  }
+
+  if (options.rollingWindowMessages && options.rollingWindowMessages > 0) {
+    const systemMessages = nextMessages.filter(
+      (message) => message.role === 'system'
+    )
+    const conversationMessages = nextMessages.filter(
+      (message) => message.role !== 'system'
+    )
+    nextMessages = [
+      ...systemMessages,
+      ...conversationMessages.slice(-options.rollingWindowMessages),
+    ]
+  }
+
+  return nextMessages
+}
+
+function dropCompletedToolCallMessages(
+  messages: LanguageModelV3Prompt
+): LanguageModelV3Prompt {
+  const lastToolRelatedIndex = findLastIndex(messages, isToolRelatedMessage)
+
+  if (lastToolRelatedIndex === -1) {
+    return messages
+  }
+
+  let latestToolExchangeStartIndex = lastToolRelatedIndex
+  while (
+    latestToolExchangeStartIndex > 0 &&
+    isToolRelatedMessage(messages[latestToolExchangeStartIndex - 1])
+  ) {
+    latestToolExchangeStartIndex -= 1
+  }
+
+  return messages.filter((message, index) => {
+    if (index >= latestToolExchangeStartIndex) {
+      return true
+    }
+
+    return !isToolRelatedMessage(message)
+  })
+}
+
+function findLastIndex<T>(
+  items: T[],
+  predicate: (item: T, index: number) => boolean
+) {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index], index)) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function isToolRelatedMessage(message: LanguageModelV3Message) {
+  if (message.role === 'tool') {
+    return true
+  }
+
+  if (message.role !== 'assistant') {
+    return false
+  }
+
+  return message.content.some(
+    (part) => part.type === 'tool-call' || part.type === 'tool-result'
+  )
+}
 
 export function createAppleProvider({
   availableTools,
-}: {
-  availableTools?: ToolDefinitionSet
-} = {}) {
-  const createLanguageModel = () => {
-    return new AppleLLMChatLanguageModel(availableTools)
+  model,
+  context,
+}: AppleLanguageModelOptions = {}) {
+  const createLanguageModel = (options: AppleLanguageModelOptions = {}) => {
+    return new AppleLLMChatLanguageModel({
+      availableTools: options.availableTools ?? availableTools,
+      model: options.model ?? model,
+      context: {
+        ...context,
+        ...options.context,
+      },
+    })
   }
-  const provider = function () {
-    return createLanguageModel()
+  const provider = function (options: AppleLanguageModelOptions = {}) {
+    return createLanguageModel(options)
   }
   provider.isAvailable = () => NativeAppleLLM.isAvailable()
+  provider.getModelInfo = (options: { locale?: string; model?: string } = {}) =>
+    NativeAppleLLM.getModelInfo(
+      options.locale,
+      options.model
+    ) as Promise<AppleModelInfo>
   provider.languageModel = createLanguageModel
   provider.textEmbeddingModel = (options: AppleEmbeddingOptions = {}) => {
     return new AppleTextEmbeddingModel(options)
   }
-  provider.imageModel = () => {
-    throw new Error('Image generation models are not supported by Apple LLM')
+  provider.imageModel = (options: AppleImageModelOptions = {}) => {
+    return new AppleImageModel(options)
   }
   provider.transcriptionModel = (options: AppleTranscriptionOptions = {}) => {
     return new AppleTranscriptionModel(options)
@@ -60,6 +337,47 @@ export function createAppleProvider({
 }
 
 export const apple = createAppleProvider()
+
+export interface AppleImageModelOptions {
+  style?: AppleImageStyle
+  personalization?: AppleImagePersonalization
+}
+
+class AppleImageModel implements ImageModelV3 {
+  readonly specificationVersion = 'v3'
+  readonly provider = 'apple'
+  readonly modelId = 'ImagePlayground'
+  readonly maxImagesPerCall = 4
+
+  private options: AppleImageModelOptions
+
+  constructor(options: AppleImageModelOptions = {}) {
+    this.options = options
+  }
+
+  async doGenerate(options: ImageModelV3CallOptions) {
+    const appleOptions = (options.providerOptions?.apple ??
+      {}) as AppleImageModelOptions
+    const images = await NativeAppleLLM.generateImages({
+      prompt: options.prompt,
+      n: options.n,
+      files: prepareImageModelFiles(options.files),
+      style: appleOptions.style ?? this.options.style,
+      personalization:
+        appleOptions.personalization ?? this.options.personalization,
+    })
+
+    return {
+      images,
+      warnings: [],
+      response: {
+        timestamp: new Date(),
+        modelId: this.modelId,
+        headers: undefined,
+      },
+    }
+  }
+}
 
 export interface AppleTranscriptionOptions {
   language?: string
@@ -234,31 +552,48 @@ class AppleLLMChatLanguageModel implements LanguageModelV3 {
   readonly supportedUrls = {}
 
   readonly provider = 'apple'
-  readonly modelId = 'system-default'
+  readonly modelId: string
 
   private tools: ToolDefinitionSet = {}
+  private options: AppleLanguageModelOptions
 
-  constructor(availableTools: ToolDefinitionSet = {}) {
-    this.updateTools(availableTools)
+  constructor(options: AppleLanguageModelOptions = {}) {
+    this.options = options
+    this.modelId = options.model ?? 'system'
+    this.updateTools(options.availableTools ?? {})
   }
 
   async prepare(): Promise<void> {}
 
   private prepareMessages(messages: LanguageModelV3Prompt): AppleMessage[] {
     return messages.map((message): AppleMessage => {
-      const content = Array.isArray(message.content)
-        ? message.content.reduce((acc, part) => {
-            if (part.type === 'text') {
-              return acc + part.text
-            }
-            console.warn('Unsupported message content type:', part)
+      if (Array.isArray(message.content)) {
+        const attachments: AppleMessageAttachment[] = []
+        const content = message.content.reduce((acc, part) => {
+          if (part.type === 'text') {
+            return acc + part.text
+          }
+
+          if (part.type === 'file') {
+            attachments.push(prepareImageAttachment(part))
             return acc
-          }, '')
-        : message.content
+          }
+
+          throw new Error(
+            `Unsupported Apple Foundation Models message content type: ${JSON.stringify(part)}`
+          )
+        }, '')
+
+        return {
+          role: message.role,
+          content,
+          attachments,
+        }
+      }
 
       return {
         role: message.role,
-        content,
+        content: message.content,
       }
     })
   }
@@ -296,7 +631,14 @@ class AppleLLMChatLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(options: LanguageModelV3CallOptions) {
-    const messages = this.prepareMessages(options.prompt)
+    const appleOptions = mergeAppleProviderOptions(
+      this.options,
+      getAppleProviderOptions(options.providerOptions)
+    )
+    const prompt = appleOptions.context
+      ? trimAppleMessagesForContext(options.prompt, appleOptions.context)
+      : options.prompt
+    const messages = this.prepareMessages(prompt)
     const tools = this.prepareTools(options.tools)
 
     for (const tool of tools) {
@@ -310,6 +652,7 @@ class AppleLLMChatLanguageModel implements LanguageModelV3 {
         topP: options.topP,
         topK: options.topK,
         tools,
+        providerOptions: appleOptions as unknown as Record<string, unknown>,
         schema:
           options.responseFormat?.type === 'json'
             ? options.responseFormat.schema
@@ -363,7 +706,14 @@ class AppleLLMChatLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(options: LanguageModelV3CallOptions) {
-    const messages = this.prepareMessages(options.prompt)
+    const appleOptions = mergeAppleProviderOptions(
+      this.options,
+      getAppleProviderOptions(options.providerOptions)
+    )
+    const prompt = appleOptions.context
+      ? trimAppleMessagesForContext(options.prompt, appleOptions.context)
+      : options.prompt
+    const messages = this.prepareMessages(prompt)
     const tools = this.prepareTools(options.tools)
 
     if (typeof ReadableStream === 'undefined') {
@@ -477,6 +827,7 @@ class AppleLLMChatLanguageModel implements LanguageModelV3 {
             topP: options.topP,
             topK: options.topK,
             tools,
+            providerOptions: appleOptions as unknown as Record<string, unknown>,
             schema,
           })
         } catch (error) {

--- a/packages/apple-llm/src/ai-sdk.ts
+++ b/packages/apple-llm/src/ai-sdk.ts
@@ -24,7 +24,6 @@ import {
   ToolCallOptions,
 } from '@ai-sdk/provider-utils'
 
-import AppleFoundationModels from './AppleFoundationModels'
 import { createAppleLLMError, isAppleLLMErrorCode } from './errors'
 import NativeAppleEmbeddings from './NativeAppleEmbeddings'
 import NativeAppleLLM, { type AppleMessage } from './NativeAppleLLM'
@@ -53,7 +52,6 @@ export type AppleImagePersonalization = 'automatic' | 'disabled' | 'enabled'
 export interface AppleProviderOptions {
   model?: AppleLanguageModelId
   builtInTools?: AppleBuiltInTool[]
-  context?: AppleContextOptions
   style?: AppleImageStyle
   personalization?: AppleImagePersonalization
 }
@@ -76,27 +74,6 @@ export interface AppleModelInfo {
 export interface AppleLanguageModelOptions {
   model?: AppleLanguageModelId
   availableTools?: AppleToolDefinitionSet
-  context?: AppleContextOptions
-}
-
-export interface AppleSummarizeHistoryOptions {
-  threshold: number
-  model: LanguageModelV3
-}
-
-export interface AppleContextOptions {
-  /**
-   * Summarize older messages when the prompt token count exceeds the threshold.
-   */
-  summarizeHistory?: AppleSummarizeHistoryOptions
-  /**
-   * Keep system messages and only the last N non-system messages.
-   */
-  rollingWindowMessages?: number
-  /**
-   * Remove completed tool-call/tool-result entries from older context.
-   */
-  dropCompletedToolCalls?: boolean
 }
 
 type AppleMessageAttachment = {
@@ -115,14 +92,6 @@ type AppleMessageContentPart = Extract<
   LanguageModelV3Message['content'],
   readonly unknown[]
 >[number]
-
-type LanguageModelLikeResult = Awaited<
-  ReturnType<LanguageModelV3['doGenerate']>
->
-
-type TokenCountCapableLanguageModel = LanguageModelV3 & {
-  countTokens?: (text: string) => Promise<number>
-}
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {
   let binary = ''
@@ -258,18 +227,6 @@ function getAppleProviderOptions(
   return (providerOptions?.apple ?? {}) as AppleProviderOptions
 }
 
-function mergeAppleContextOptions(
-  defaults: AppleContextOptions | undefined,
-  callOptions: AppleContextOptions | undefined
-): AppleContextOptions | undefined {
-  const context = {
-    ...defaults,
-    ...callOptions,
-  }
-
-  return Object.keys(context).length > 0 ? context : undefined
-}
-
 function mergeAppleProviderOptions(
   defaults: AppleLanguageModelOptions,
   callOptions: AppleProviderOptions
@@ -277,134 +234,7 @@ function mergeAppleProviderOptions(
   return {
     model: callOptions.model ?? defaults.model,
     builtInTools: callOptions.builtInTools,
-    context: mergeAppleContextOptions(defaults.context, callOptions.context),
   }
-}
-
-function getNativeAppleProviderOptions(
-  options: AppleProviderOptions
-): Omit<AppleProviderOptions, 'context'> {
-  const nativeOptions = { ...options }
-  delete nativeOptions.context
-  return nativeOptions
-}
-
-async function summarizePromptHistory(
-  prompt: LanguageModelV3Prompt,
-  threshold: number,
-  summarizerModel: LanguageModelV3
-): Promise<LanguageModelV3Prompt> {
-  if (threshold <= 0) {
-    return prompt
-  }
-
-  const promptTokenCount = await countPromptTokens(prompt, summarizerModel)
-
-  if (promptTokenCount <= threshold) {
-    return prompt
-  }
-
-  const systemMessages = prompt.filter((message) => message.role === 'system')
-  const conversationMessages = prompt.filter(
-    (message) => message.role !== 'system'
-  )
-
-  if (conversationMessages.length <= 2) {
-    return prompt
-  }
-
-  const latestMessage = conversationMessages[conversationMessages.length - 1]
-  const messagesToSummarize = conversationMessages.slice(0, -1)
-
-  if (messagesToSummarize.length === 0) {
-    return prompt
-  }
-
-  const summaryPrompt = buildSummaryPrompt(messagesToSummarize)
-  const summaryResult = await summarizerModel.doGenerate({
-    prompt: summaryPrompt,
-    maxOutputTokens: 400,
-  } as LanguageModelV3CallOptions)
-  const summaryText = extractTextFromGenerationResult(summaryResult).trim()
-
-  if (!summaryText) {
-    return prompt
-  }
-
-  return [
-    ...systemMessages,
-    {
-      role: 'assistant',
-      content: [
-        {
-          type: 'text',
-          text: `Summary of earlier conversation:\n${summaryText}`,
-        },
-      ],
-    },
-    latestMessage,
-  ]
-}
-
-async function countPromptTokens(
-  prompt: LanguageModelV3Prompt,
-  model: LanguageModelV3
-): Promise<number> {
-  const serializedPrompt = serializePromptForSummary(prompt)
-  const countTokens =
-    (model as TokenCountCapableLanguageModel).countTokens ??
-    (model.provider === 'apple' ? AppleFoundationModels.countTokens : undefined)
-
-  if (typeof countTokens === 'function') {
-    try {
-      return await countTokens(serializedPrompt)
-    } catch {
-      return estimateTokenCount(serializedPrompt)
-    }
-  }
-
-  return estimateTokenCount(serializedPrompt)
-}
-
-function estimateTokenCount(text: string): number {
-  if (!text.trim()) {
-    return 0
-  }
-
-  return Math.ceil(text.length / 4)
-}
-
-function buildSummaryPrompt(
-  messages: LanguageModelV3Prompt
-): LanguageModelV3Prompt {
-  return [
-    {
-      role: 'system',
-      content:
-        'Summarize the conversation history for continued assistant use. Preserve user goals, constraints, factual details, decisions, unresolved questions, and tool outcomes. Be concise and structured.',
-    },
-    {
-      role: 'user',
-      content: [
-        {
-          type: 'text',
-          text: serializePromptForSummary(messages),
-        },
-      ],
-    },
-  ]
-}
-
-function serializePromptForSummary(messages: LanguageModelV3Prompt): string {
-  return messages
-    .map((message) => {
-      const content = Array.isArray(message.content)
-        ? message.content.map(serializeMessageContentPart).join('\n')
-        : message.content
-
-      return `${message.role.toUpperCase()}: ${content}`
-    })
-    .join('\n\n')
 }
 
 function serializeKnownMessageContentPart(
@@ -427,10 +257,6 @@ function serializeKnownMessageContentPart(
   }
 }
 
-function serializeMessageContentPart(part: AppleMessageContentPart): string {
-  return serializeKnownMessageContentPart(part) ?? `[${part.type}]`
-}
-
 function appendMessageContent(content: string, addition: string) {
   if (!addition) {
     return content
@@ -439,134 +265,9 @@ function appendMessageContent(content: string, addition: string) {
   return content ? `${content}\n${addition}` : addition
 }
 
-function extractTextFromGenerationResult(
-  result: LanguageModelLikeResult
-): string {
-  return result.content
-    .map((part) => (part.type === 'text' ? part.text : ''))
-    .join('')
-}
-
-export function trimAppleMessagesForContext(
-  messages: LanguageModelV3Prompt,
-  options: AppleContextOptions = {}
-): LanguageModelV3Prompt {
-  let nextMessages = messages
-
-  if (options.dropCompletedToolCalls) {
-    nextMessages = dropCompletedToolCallMessages(nextMessages)
-  }
-
-  if (options.rollingWindowMessages && options.rollingWindowMessages > 0) {
-    const systemMessages = nextMessages.filter(
-      (message) => message.role === 'system'
-    )
-    const conversationMessages = nextMessages.filter(
-      (message) => message.role !== 'system'
-    )
-    nextMessages = [
-      ...systemMessages,
-      ...conversationMessages.slice(-options.rollingWindowMessages),
-    ]
-  }
-
-  return nextMessages
-}
-
-function dropCompletedToolCallMessages(
-  messages: LanguageModelV3Prompt
-): LanguageModelV3Prompt {
-  const lastToolRelatedIndex = findLastIndex(messages, isToolRelatedMessage)
-
-  if (lastToolRelatedIndex === -1) {
-    return messages
-  }
-
-  let latestToolExchangeStartIndex = lastToolRelatedIndex
-  while (
-    latestToolExchangeStartIndex > 0 &&
-    isToolRelatedMessage(messages[latestToolExchangeStartIndex - 1])
-  ) {
-    latestToolExchangeStartIndex -= 1
-  }
-
-  return messages.filter((message, index) => {
-    if (index >= latestToolExchangeStartIndex) {
-      return true
-    }
-
-    return !isToolRelatedMessage(message)
-  })
-}
-
-function findLastIndex<T>(
-  items: T[],
-  predicate: (item: T, index: number) => boolean
-) {
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    if (predicate(items[index], index)) {
-      return index
-    }
-  }
-
-  return -1
-}
-
-function isToolRelatedMessage(message: LanguageModelV3Message) {
-  if (message.role === 'tool') {
-    return true
-  }
-
-  if (message.role !== 'assistant') {
-    return false
-  }
-
-  if (!Array.isArray(message.content)) {
-    return false
-  }
-
-  return message.content.some(
-    (part) => part.type === 'tool-call' || part.type === 'tool-result'
-  )
-}
-
-async function applyAppleContextOptions(
-  prompt: LanguageModelV3Prompt,
-  context: AppleContextOptions | undefined
-): Promise<LanguageModelV3Prompt> {
-  if (!context) {
-    return prompt
-  }
-
-  let nextPrompt = prompt
-
-  if (context.dropCompletedToolCalls) {
-    nextPrompt = trimAppleMessagesForContext(nextPrompt, {
-      dropCompletedToolCalls: true,
-    })
-  }
-
-  if (context.rollingWindowMessages && context.rollingWindowMessages > 0) {
-    nextPrompt = trimAppleMessagesForContext(nextPrompt, {
-      rollingWindowMessages: context.rollingWindowMessages,
-    })
-  }
-
-  if (context.summarizeHistory) {
-    nextPrompt = await summarizePromptHistory(
-      nextPrompt,
-      context.summarizeHistory.threshold,
-      context.summarizeHistory.model
-    )
-  }
-
-  return nextPrompt
-}
-
 export function createAppleProvider({
   availableTools,
   model,
-  context,
 }: AppleLanguageModelOptions = {}) {
   const createLanguageModel = (
     options: AppleLanguageModelOptions = {}
@@ -574,7 +275,6 @@ export function createAppleProvider({
     return new AppleLLMChatLanguageModel({
       availableTools: options.availableTools ?? availableTools,
       model: options.model ?? model,
-      context: mergeAppleContextOptions(context, options.context),
     })
   }
   const provider = function (options: AppleLanguageModelOptions = {}) {
@@ -902,11 +602,7 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
       this.options,
       getAppleProviderOptions(options.providerOptions)
     )
-    const prompt = await applyAppleContextOptions(
-      options.prompt,
-      appleOptions.context
-    )
-    const messages = this.prepareMessages(prompt)
+    const messages = this.prepareMessages(options.prompt)
     const tools = this.prepareTools(options.tools)
 
     for (const tool of tools) {
@@ -920,9 +616,7 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
         topP: options.topP,
         topK: options.topK,
         tools,
-        providerOptions: getNativeAppleProviderOptions(
-          appleOptions
-        ) as unknown as Record<string, unknown>,
+        providerOptions: appleOptions as unknown as Record<string, unknown>,
         schema:
           options.responseFormat?.type === 'json'
             ? options.responseFormat.schema
@@ -980,11 +674,7 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
       this.options,
       getAppleProviderOptions(options.providerOptions)
     )
-    const prompt = await applyAppleContextOptions(
-      options.prompt,
-      appleOptions.context
-    )
-    const messages = this.prepareMessages(prompt)
+    const messages = this.prepareMessages(options.prompt)
     const tools = this.prepareTools(options.tools)
 
     if (typeof ReadableStream === 'undefined') {
@@ -1098,9 +788,7 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
             topP: options.topP,
             topK: options.topK,
             tools,
-            providerOptions: getNativeAppleProviderOptions(
-              appleOptions
-            ) as unknown as Record<string, unknown>,
+            providerOptions: appleOptions as unknown as Record<string, unknown>,
             schema,
           })
         } catch (error) {

--- a/packages/apple-llm/src/ai-sdk.ts
+++ b/packages/apple-llm/src/ai-sdk.ts
@@ -6,8 +6,8 @@ import type {
   ImageModelV3CallOptions,
   LanguageModelV3,
   LanguageModelV3CallOptions,
-  LanguageModelV3Message,
   LanguageModelV3FunctionTool,
+  LanguageModelV3Message,
   LanguageModelV3Prompt,
   LanguageModelV3ProviderTool,
   LanguageModelV3StreamPart,
@@ -24,6 +24,7 @@ import {
   ToolCallOptions,
 } from '@ai-sdk/provider-utils'
 
+import AppleFoundationModels from './AppleFoundationModels'
 import { createAppleLLMError, isAppleLLMErrorCode } from './errors'
 import NativeAppleEmbeddings from './NativeAppleEmbeddings'
 import NativeAppleLLM, { type AppleMessage } from './NativeAppleLLM'
@@ -32,7 +33,23 @@ import NativeAppleTranscription from './NativeAppleTranscription'
 import NativeAppleUtils from './NativeAppleUtils'
 
 type Tool = LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
-type ToolDefinitionSet = Record<string, FullToolDefinition>
+export type AppleToolDefinitionSet = Record<string, FullToolDefinition>
+type HistoryTransform = {
+  apply: (
+    prompt: LanguageModelV3Prompt
+  ) => Promise<LanguageModelV3Prompt> | LanguageModelV3Prompt
+}
+
+export interface AppleLanguageModel extends LanguageModelV3 {
+  prepare: () => Promise<void>
+  updateTools: (tools: AppleToolDefinitionSet) => void
+  summarizeHistory: (
+    threshold: number,
+    model: LanguageModelV3
+  ) => AppleLanguageModel
+  rollingWindow: (entries: number) => AppleLanguageModel
+  droppingCompletedToolCalls: () => AppleLanguageModel
+}
 export type AppleLanguageModelId = 'system' | 'private-cloud-compute'
 export type AppleBuiltInTool = 'ocr' | 'barcode'
 export type AppleImageStyle =
@@ -69,7 +86,7 @@ export interface AppleModelInfo {
 
 export interface AppleLanguageModelOptions {
   model?: AppleLanguageModelId
-  availableTools?: ToolDefinitionSet
+  availableTools?: AppleToolDefinitionSet
   context?: AppleContextOptions
 }
 
@@ -94,6 +111,14 @@ type AppleMessageAttachment = {
 type AppleImageModelFile = {
   mediaType: string
   data: string
+}
+
+type LanguageModelLikeResult = Awaited<
+  ReturnType<LanguageModelV3['doGenerate']>
+>
+
+type TokenCountCapableLanguageModel = LanguageModelV3 & {
+  countTokens?: (text: string) => Promise<number>
 }
 
 function uint8ArrayToBase64(bytes: Uint8Array): string {
@@ -217,6 +242,152 @@ function mergeAppleProviderOptions(
   }
 }
 
+async function summarizePromptHistory(
+  prompt: LanguageModelV3Prompt,
+  threshold: number,
+  summarizerModel: LanguageModelV3
+): Promise<LanguageModelV3Prompt> {
+  if (threshold <= 0) {
+    return prompt
+  }
+
+  const promptTokenCount = await countPromptTokens(prompt, summarizerModel)
+
+  if (promptTokenCount <= threshold) {
+    return prompt
+  }
+
+  const systemMessages = prompt.filter((message) => message.role === 'system')
+  const conversationMessages = prompt.filter(
+    (message) => message.role !== 'system'
+  )
+
+  if (conversationMessages.length <= 2) {
+    return prompt
+  }
+
+  const latestMessage = conversationMessages[conversationMessages.length - 1]
+  const messagesToSummarize = conversationMessages.slice(0, -1)
+
+  if (messagesToSummarize.length === 0) {
+    return prompt
+  }
+
+  const summaryPrompt = buildSummaryPrompt(messagesToSummarize)
+  const summaryResult = await summarizerModel.doGenerate({
+    prompt: summaryPrompt,
+    maxOutputTokens: 400,
+  } as LanguageModelV3CallOptions)
+  const summaryText = extractTextFromGenerationResult(summaryResult).trim()
+
+  if (!summaryText) {
+    return prompt
+  }
+
+  return [
+    ...systemMessages,
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: `Summary of earlier conversation:\n${summaryText}`,
+        },
+      ],
+    },
+    latestMessage,
+  ]
+}
+
+async function countPromptTokens(
+  prompt: LanguageModelV3Prompt,
+  model: LanguageModelV3
+): Promise<number> {
+  const serializedPrompt = serializePromptForSummary(prompt)
+  const countTokens =
+    (model as TokenCountCapableLanguageModel).countTokens ??
+    (model.provider === 'apple' ? AppleFoundationModels.countTokens : undefined)
+
+  if (typeof countTokens === 'function') {
+    try {
+      return await countTokens(serializedPrompt)
+    } catch {
+      return estimateTokenCount(serializedPrompt)
+    }
+  }
+
+  return estimateTokenCount(serializedPrompt)
+}
+
+function estimateTokenCount(text: string): number {
+  if (!text.trim()) {
+    return 0
+  }
+
+  return Math.ceil(text.length / 4)
+}
+
+function buildSummaryPrompt(
+  messages: LanguageModelV3Prompt
+): LanguageModelV3Prompt {
+  return [
+    {
+      role: 'system',
+      content:
+        'Summarize the conversation history for continued assistant use. Preserve user goals, constraints, factual details, decisions, unresolved questions, and tool outcomes. Be concise and structured.',
+    },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: serializePromptForSummary(messages),
+        },
+      ],
+    },
+  ]
+}
+
+function serializePromptForSummary(messages: LanguageModelV3Prompt): string {
+  return messages
+    .map((message) => {
+      const content = Array.isArray(message.content)
+        ? message.content
+            .map((part) => {
+              if (part.type === 'text') {
+                return part.text
+              }
+
+              if (part.type === 'file') {
+                return `[file:${part.mediaType}]`
+              }
+
+              if (part.type === 'tool-call') {
+                return `[tool-call:${part.toolName}] ${JSON.stringify(part.input)}`
+              }
+
+              if (part.type === 'tool-result') {
+                return `[tool-result:${part.toolName}] ${JSON.stringify(part.output)}`
+              }
+
+              return `[${part.type}]`
+            })
+            .join('\n')
+        : message.content
+
+      return `${message.role.toUpperCase()}: ${content}`
+    })
+    .join('\n\n')
+}
+
+function extractTextFromGenerationResult(
+  result: LanguageModelLikeResult
+): string {
+  return result.content
+    .map((part) => (part.type === 'text' ? part.text : ''))
+    .join('')
+}
+
 export function trimAppleMessagesForContext(
   messages: LanguageModelV3Prompt,
   options: AppleContextOptions = {}
@@ -301,7 +472,9 @@ export function createAppleProvider({
   model,
   context,
 }: AppleLanguageModelOptions = {}) {
-  const createLanguageModel = (options: AppleLanguageModelOptions = {}) => {
+  const createLanguageModel = (
+    options: AppleLanguageModelOptions = {}
+  ): AppleLanguageModel => {
     return new AppleLLMChatLanguageModel({
       availableTools: options.availableTools ?? availableTools,
       model: options.model ?? model,
@@ -547,18 +720,23 @@ class AppleTextEmbeddingModel implements EmbeddingModelV3 {
   }
 }
 
-class AppleLLMChatLanguageModel implements LanguageModelV3 {
+class AppleLLMChatLanguageModel implements AppleLanguageModel {
+  private historyTransforms: HistoryTransform[]
   readonly specificationVersion = 'v3'
   readonly supportedUrls = {}
 
   readonly provider = 'apple'
   readonly modelId: string
 
-  private tools: ToolDefinitionSet = {}
+  private tools: AppleToolDefinitionSet = {}
   private options: AppleLanguageModelOptions
 
-  constructor(options: AppleLanguageModelOptions = {}) {
+  constructor(
+    options: AppleLanguageModelOptions = {},
+    historyTransforms: HistoryTransform[] = []
+  ) {
     this.options = options
+    this.historyTransforms = historyTransforms
     this.modelId = options.model ?? 'system'
     this.updateTools(options.availableTools ?? {})
   }
@@ -626,8 +804,52 @@ class AppleLLMChatLanguageModel implements LanguageModelV3 {
     })
   }
 
-  updateTools(tools: ToolDefinitionSet) {
+  updateTools(tools: AppleToolDefinitionSet) {
     this.tools = tools
+  }
+
+  summarizeHistory(
+    threshold: number,
+    summarizerModel: LanguageModelV3
+  ): AppleLanguageModel {
+    return this.withHistoryTransform((prompt) =>
+      summarizePromptHistory(prompt, threshold, summarizerModel)
+    )
+  }
+
+  rollingWindow(entries: number): AppleLanguageModel {
+    return this.withHistoryTransform((prompt) =>
+      trimAppleMessagesForContext(prompt, {
+        rollingWindowMessages: entries,
+      })
+    )
+  }
+
+  droppingCompletedToolCalls(): AppleLanguageModel {
+    return this.withHistoryTransform((prompt) =>
+      trimAppleMessagesForContext(prompt, {
+        dropCompletedToolCalls: true,
+      })
+    )
+  }
+
+  private withHistoryTransform(apply: HistoryTransform['apply']) {
+    const model = new AppleLLMChatLanguageModel(this.options, [
+      { apply },
+      ...this.historyTransforms,
+    ])
+    model.updateTools({ ...this.tools })
+    return model
+  }
+
+  private async applyHistoryTransforms(prompt: LanguageModelV3Prompt) {
+    let nextPrompt = prompt
+
+    for (const transform of this.historyTransforms) {
+      nextPrompt = await transform.apply(nextPrompt)
+    }
+
+    return nextPrompt
   }
 
   async doGenerate(options: LanguageModelV3CallOptions) {
@@ -635,9 +857,10 @@ class AppleLLMChatLanguageModel implements LanguageModelV3 {
       this.options,
       getAppleProviderOptions(options.providerOptions)
     )
+    const transformedPrompt = await this.applyHistoryTransforms(options.prompt)
     const prompt = appleOptions.context
-      ? trimAppleMessagesForContext(options.prompt, appleOptions.context)
-      : options.prompt
+      ? trimAppleMessagesForContext(transformedPrompt, appleOptions.context)
+      : transformedPrompt
     const messages = this.prepareMessages(prompt)
     const tools = this.prepareTools(options.tools)
 
@@ -710,9 +933,10 @@ class AppleLLMChatLanguageModel implements LanguageModelV3 {
       this.options,
       getAppleProviderOptions(options.providerOptions)
     )
+    const transformedPrompt = await this.applyHistoryTransforms(options.prompt)
     const prompt = appleOptions.context
-      ? trimAppleMessagesForContext(options.prompt, appleOptions.context)
-      : options.prompt
+      ? trimAppleMessagesForContext(transformedPrompt, appleOptions.context)
+      : transformedPrompt
     const messages = this.prepareMessages(prompt)
     const tools = this.prepareTools(options.tools)
 

--- a/packages/apple-llm/src/ai-sdk.ts
+++ b/packages/apple-llm/src/ai-sdk.ts
@@ -111,6 +111,11 @@ type AppleImageModelFile = {
   data: string
 }
 
+type AppleMessageContentPart = Extract<
+  LanguageModelV3Message['content'],
+  readonly unknown[]
+>[number]
+
 type LanguageModelLikeResult = Awaited<
   ReturnType<LanguageModelV3['doGenerate']>
 >
@@ -186,9 +191,27 @@ function prepareImageModelFiles(
 ): AppleImageModelFile[] {
   return files.map((file) => {
     if (file.type === 'url') {
+      const url = file.url.toString()
+
+      if (url.startsWith('http://') || url.startsWith('https://')) {
+        throw new Error(
+          'Remote Apple Image Playground file URLs are not supported. Provide image data, a data URL, or a local file URL instead.'
+        )
+      }
+
+      if (
+        !url.startsWith('data:') &&
+        !url.startsWith('file://') &&
+        !url.startsWith('/')
+      ) {
+        throw new Error(
+          'Unsupported Apple Image Playground file URL. Provide image data, a data URL, or a local file URL instead.'
+        )
+      }
+
       return {
-        mediaType: 'image/png',
-        data: file.url,
+        mediaType: getImageModelFileUrlMediaType(url),
+        data: url,
       }
     }
 
@@ -218,6 +241,15 @@ function prepareImageModelFiles(
       data: normalizedData,
     }
   })
+}
+
+function getImageModelFileUrlMediaType(url: string) {
+  if (!url.startsWith('data:')) {
+    return 'image/png'
+  }
+
+  const [, mediaType] = /^data:([^;,]+)/.exec(url) ?? []
+  return mediaType?.toLowerCase() ?? 'image/png'
 }
 
 function getAppleProviderOptions(
@@ -367,32 +399,44 @@ function serializePromptForSummary(messages: LanguageModelV3Prompt): string {
   return messages
     .map((message) => {
       const content = Array.isArray(message.content)
-        ? message.content
-            .map((part) => {
-              if (part.type === 'text') {
-                return part.text
-              }
-
-              if (part.type === 'file') {
-                return `[file:${part.mediaType}]`
-              }
-
-              if (part.type === 'tool-call') {
-                return `[tool-call:${part.toolName}] ${JSON.stringify(part.input)}`
-              }
-
-              if (part.type === 'tool-result') {
-                return `[tool-result:${part.toolName}] ${JSON.stringify(part.output)}`
-              }
-
-              return `[${part.type}]`
-            })
-            .join('\n')
+        ? message.content.map(serializeMessageContentPart).join('\n')
         : message.content
 
       return `${message.role.toUpperCase()}: ${content}`
     })
     .join('\n\n')
+}
+
+function serializeKnownMessageContentPart(
+  part: AppleMessageContentPart
+): string | undefined {
+  if (part.type === 'text') {
+    return part.text
+  }
+
+  if (part.type === 'file') {
+    return `[file:${part.mediaType}]`
+  }
+
+  if (part.type === 'tool-call') {
+    return `[tool-call:${part.toolName}] ${JSON.stringify(part.input)}`
+  }
+
+  if (part.type === 'tool-result') {
+    return `[tool-result:${part.toolName}] ${JSON.stringify(part.output)}`
+  }
+}
+
+function serializeMessageContentPart(part: AppleMessageContentPart): string {
+  return serializeKnownMessageContentPart(part) ?? `[${part.type}]`
+}
+
+function appendMessageContent(content: string, addition: string) {
+  if (!addition) {
+    return content
+  }
+
+  return content ? `${content}\n${addition}` : addition
 }
 
 function extractTextFromGenerationResult(
@@ -792,13 +836,14 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
       if (Array.isArray(message.content)) {
         const attachments: AppleMessageAttachment[] = []
         const content = message.content.reduce((acc, part) => {
-          if (part.type === 'text') {
-            return acc + part.text
-          }
-
           if (part.type === 'file') {
             attachments.push(prepareImageAttachment(part))
             return acc
+          }
+
+          const serializedPart = serializeKnownMessageContentPart(part)
+          if (serializedPart !== undefined) {
+            return appendMessageContent(acc, serializedPart)
           }
 
           throw new Error(

--- a/packages/apple-llm/src/ai-sdk.ts
+++ b/packages/apple-llm/src/ai-sdk.ts
@@ -64,11 +64,9 @@ export interface AppleModelInfo {
   supportedLanguages: string[]
   supportsTokenCounting: boolean
   supportsImagePrompts: boolean
-  supportsPrivateCloudCompute: boolean
   supportsDynamicProfiles: boolean
   supportsVisionTools: boolean
   contextSize?: number
-  quotaUsage?: string
 }
 
 export interface AppleLanguageModelOptions {
@@ -88,6 +86,16 @@ type AppleImageModelFile = {
   data: string
 }
 
+type AppleImageSource =
+  | {
+      type: 'data'
+      value: string
+    }
+  | {
+      type: 'url'
+      value: string
+    }
+
 type AppleMessageContentPart = Extract<
   LanguageModelV3Message['content'],
   readonly unknown[]
@@ -101,6 +109,62 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
     binary += String.fromCharCode(...chunk)
   }
   return btoa(binary)
+}
+
+function normalizeAppleImageSource(
+  data: unknown,
+  featureName: string
+): AppleImageSource {
+  if (data instanceof Uint8Array) {
+    return {
+      type: 'data',
+      value: uint8ArrayToBase64(data),
+    }
+  }
+
+  const value =
+    data instanceof URL
+      ? data.toString()
+      : typeof data === 'string'
+        ? data
+        : null
+
+  if (!value) {
+    throw new Error(`Unsupported ${featureName} image data`)
+  }
+
+  const lowerValue = value.toLowerCase()
+
+  if (lowerValue.startsWith('http://') || lowerValue.startsWith('https://')) {
+    throw new Error(
+      `Remote ${featureName} image URLs are not supported. Provide image data, a data URL, or a local file URL instead.`
+    )
+  }
+
+  if (lowerValue.startsWith('data:')) {
+    return {
+      type: 'data',
+      value,
+    }
+  }
+
+  if (lowerValue.startsWith('file://') || value.startsWith('/')) {
+    return {
+      type: 'url',
+      value,
+    }
+  }
+
+  if (/^[a-z][a-z\d+.-]*:/i.test(value)) {
+    throw new Error(
+      `Unsupported ${featureName} image URL. Provide image data, a data URL, or a local file URL instead.`
+    )
+  }
+
+  return {
+    type: 'data',
+    value,
+  }
 }
 
 function prepareImageAttachment(
@@ -119,39 +183,23 @@ function prepareImageAttachment(
     )
   }
 
-  const data = part.data as unknown
+  const source = normalizeAppleImageSource(
+    part.data as unknown,
+    'Apple Foundation Models'
+  )
 
-  if (data instanceof Uint8Array) {
+  if (source.type === 'data') {
     return {
       type: 'image',
       mediaType,
-      data: uint8ArrayToBase64(data),
-    }
-  }
-
-  const value =
-    data instanceof URL
-      ? data.toString()
-      : typeof data === 'string'
-        ? data
-        : null
-
-  if (!value) {
-    throw new Error('Unsupported Apple Foundation Models image data')
-  }
-
-  if (value.startsWith('data:')) {
-    return {
-      type: 'image',
-      mediaType,
-      data: value,
+      data: source.value,
     }
   }
 
   return {
     type: 'image',
     mediaType,
-    url: value,
+    url: source.value,
   }
 }
 
@@ -160,27 +208,14 @@ function prepareImageModelFiles(
 ): AppleImageModelFile[] {
   return files.map((file) => {
     if (file.type === 'url') {
-      const url = file.url.toString()
-
-      if (url.startsWith('http://') || url.startsWith('https://')) {
-        throw new Error(
-          'Remote Apple Image Playground file URLs are not supported. Provide image data, a data URL, or a local file URL instead.'
-        )
-      }
-
-      if (
-        !url.startsWith('data:') &&
-        !url.startsWith('file://') &&
-        !url.startsWith('/')
-      ) {
-        throw new Error(
-          'Unsupported Apple Image Playground file URL. Provide image data, a data URL, or a local file URL instead.'
-        )
-      }
+      const source = normalizeAppleImageSource(
+        file.url,
+        'Apple Image Playground'
+      )
 
       return {
-        mediaType: getImageModelFileUrlMediaType(url),
-        data: url,
+        mediaType: getImageModelFileUrlMediaType(source.value),
+        data: source.value,
       }
     }
 
@@ -191,23 +226,14 @@ function prepareImageModelFiles(
       )
     }
 
-    const data = file.data as unknown
-    const normalizedData =
-      data instanceof Uint8Array
-        ? uint8ArrayToBase64(data)
-        : data instanceof URL
-          ? data.toString()
-          : typeof data === 'string'
-            ? data
-            : null
-
-    if (!normalizedData) {
-      throw new Error('Unsupported Apple Image Playground image data')
-    }
+    const source = normalizeAppleImageSource(
+      file.data as unknown,
+      'Apple Image Playground'
+    )
 
     return {
       mediaType,
-      data: normalizedData,
+      data: source.value,
     }
   })
 }
@@ -281,7 +307,9 @@ export function createAppleProvider({
     return createLanguageModel(options)
   }
   provider.isAvailable = () => NativeAppleLLM.isAvailable()
-  provider.getModelInfo = (options: { locale?: string; model?: string } = {}) =>
+  provider.getModelInfo = (
+    options: { locale?: string; model?: AppleLanguageModelId } = {}
+  ) =>
     NativeAppleLLM.getModelInfo(
       options.locale,
       options.model

--- a/packages/apple-llm/src/ai-sdk.ts
+++ b/packages/apple-llm/src/ai-sdk.ts
@@ -34,21 +34,10 @@ import NativeAppleUtils from './NativeAppleUtils'
 
 type Tool = LanguageModelV3FunctionTool | LanguageModelV3ProviderTool
 export type AppleToolDefinitionSet = Record<string, FullToolDefinition>
-type HistoryTransform = {
-  apply: (
-    prompt: LanguageModelV3Prompt
-  ) => Promise<LanguageModelV3Prompt> | LanguageModelV3Prompt
-}
 
 export interface AppleLanguageModel extends LanguageModelV3 {
   prepare: () => Promise<void>
   updateTools: (tools: AppleToolDefinitionSet) => void
-  summarizeHistory: (
-    threshold: number,
-    model: LanguageModelV3
-  ) => AppleLanguageModel
-  rollingWindow: (entries: number) => AppleLanguageModel
-  droppingCompletedToolCalls: () => AppleLanguageModel
 }
 export type AppleLanguageModelId = 'system' | 'private-cloud-compute'
 export type AppleBuiltInTool = 'ocr' | 'barcode'
@@ -90,9 +79,18 @@ export interface AppleLanguageModelOptions {
   context?: AppleContextOptions
 }
 
+export interface AppleSummarizeHistoryOptions {
+  threshold: number
+  model: LanguageModelV3
+}
+
 export interface AppleContextOptions {
   /**
-   * Keep the first system message and only the last N non-system messages.
+   * Summarize older messages when the prompt token count exceeds the threshold.
+   */
+  summarizeHistory?: AppleSummarizeHistoryOptions
+  /**
+   * Keep system messages and only the last N non-system messages.
    */
   rollingWindowMessages?: number
   /**
@@ -228,6 +226,18 @@ function getAppleProviderOptions(
   return (providerOptions?.apple ?? {}) as AppleProviderOptions
 }
 
+function mergeAppleContextOptions(
+  defaults: AppleContextOptions | undefined,
+  callOptions: AppleContextOptions | undefined
+): AppleContextOptions | undefined {
+  const context = {
+    ...defaults,
+    ...callOptions,
+  }
+
+  return Object.keys(context).length > 0 ? context : undefined
+}
+
 function mergeAppleProviderOptions(
   defaults: AppleLanguageModelOptions,
   callOptions: AppleProviderOptions
@@ -235,11 +245,16 @@ function mergeAppleProviderOptions(
   return {
     model: callOptions.model ?? defaults.model,
     builtInTools: callOptions.builtInTools,
-    context: {
-      ...defaults.context,
-      ...callOptions.context,
-    },
+    context: mergeAppleContextOptions(defaults.context, callOptions.context),
   }
+}
+
+function getNativeAppleProviderOptions(
+  options: AppleProviderOptions
+): Omit<AppleProviderOptions, 'context'> {
+  const nativeOptions = { ...options }
+  delete nativeOptions.context
+  return nativeOptions
 }
 
 async function summarizePromptHistory(
@@ -467,6 +482,39 @@ function isToolRelatedMessage(message: LanguageModelV3Message) {
   )
 }
 
+async function applyAppleContextOptions(
+  prompt: LanguageModelV3Prompt,
+  context: AppleContextOptions | undefined
+): Promise<LanguageModelV3Prompt> {
+  if (!context) {
+    return prompt
+  }
+
+  let nextPrompt = prompt
+
+  if (context.dropCompletedToolCalls) {
+    nextPrompt = trimAppleMessagesForContext(nextPrompt, {
+      dropCompletedToolCalls: true,
+    })
+  }
+
+  if (context.rollingWindowMessages && context.rollingWindowMessages > 0) {
+    nextPrompt = trimAppleMessagesForContext(nextPrompt, {
+      rollingWindowMessages: context.rollingWindowMessages,
+    })
+  }
+
+  if (context.summarizeHistory) {
+    nextPrompt = await summarizePromptHistory(
+      nextPrompt,
+      context.summarizeHistory.threshold,
+      context.summarizeHistory.model
+    )
+  }
+
+  return nextPrompt
+}
+
 export function createAppleProvider({
   availableTools,
   model,
@@ -478,10 +526,7 @@ export function createAppleProvider({
     return new AppleLLMChatLanguageModel({
       availableTools: options.availableTools ?? availableTools,
       model: options.model ?? model,
-      context: {
-        ...context,
-        ...options.context,
-      },
+      context: mergeAppleContextOptions(context, options.context),
     })
   }
   const provider = function (options: AppleLanguageModelOptions = {}) {
@@ -721,7 +766,6 @@ class AppleTextEmbeddingModel implements EmbeddingModelV3 {
 }
 
 class AppleLLMChatLanguageModel implements AppleLanguageModel {
-  private historyTransforms: HistoryTransform[]
   readonly specificationVersion = 'v3'
   readonly supportedUrls = {}
 
@@ -731,12 +775,8 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
   private tools: AppleToolDefinitionSet = {}
   private options: AppleLanguageModelOptions
 
-  constructor(
-    options: AppleLanguageModelOptions = {},
-    historyTransforms: HistoryTransform[] = []
-  ) {
+  constructor(options: AppleLanguageModelOptions = {}) {
     this.options = options
-    this.historyTransforms = historyTransforms
     this.modelId = options.model ?? 'system'
     this.updateTools(options.availableTools ?? {})
   }
@@ -808,59 +848,15 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
     this.tools = tools
   }
 
-  summarizeHistory(
-    threshold: number,
-    summarizerModel: LanguageModelV3
-  ): AppleLanguageModel {
-    return this.withHistoryTransform((prompt) =>
-      summarizePromptHistory(prompt, threshold, summarizerModel)
-    )
-  }
-
-  rollingWindow(entries: number): AppleLanguageModel {
-    return this.withHistoryTransform((prompt) =>
-      trimAppleMessagesForContext(prompt, {
-        rollingWindowMessages: entries,
-      })
-    )
-  }
-
-  droppingCompletedToolCalls(): AppleLanguageModel {
-    return this.withHistoryTransform((prompt) =>
-      trimAppleMessagesForContext(prompt, {
-        dropCompletedToolCalls: true,
-      })
-    )
-  }
-
-  private withHistoryTransform(apply: HistoryTransform['apply']) {
-    const model = new AppleLLMChatLanguageModel(this.options, [
-      { apply },
-      ...this.historyTransforms,
-    ])
-    model.updateTools({ ...this.tools })
-    return model
-  }
-
-  private async applyHistoryTransforms(prompt: LanguageModelV3Prompt) {
-    let nextPrompt = prompt
-
-    for (const transform of this.historyTransforms) {
-      nextPrompt = await transform.apply(nextPrompt)
-    }
-
-    return nextPrompt
-  }
-
   async doGenerate(options: LanguageModelV3CallOptions) {
     const appleOptions = mergeAppleProviderOptions(
       this.options,
       getAppleProviderOptions(options.providerOptions)
     )
-    const transformedPrompt = await this.applyHistoryTransforms(options.prompt)
-    const prompt = appleOptions.context
-      ? trimAppleMessagesForContext(transformedPrompt, appleOptions.context)
-      : transformedPrompt
+    const prompt = await applyAppleContextOptions(
+      options.prompt,
+      appleOptions.context
+    )
     const messages = this.prepareMessages(prompt)
     const tools = this.prepareTools(options.tools)
 
@@ -875,7 +871,9 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
         topP: options.topP,
         topK: options.topK,
         tools,
-        providerOptions: appleOptions as unknown as Record<string, unknown>,
+        providerOptions: getNativeAppleProviderOptions(
+          appleOptions
+        ) as unknown as Record<string, unknown>,
         schema:
           options.responseFormat?.type === 'json'
             ? options.responseFormat.schema
@@ -933,10 +931,10 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
       this.options,
       getAppleProviderOptions(options.providerOptions)
     )
-    const transformedPrompt = await this.applyHistoryTransforms(options.prompt)
-    const prompt = appleOptions.context
-      ? trimAppleMessagesForContext(transformedPrompt, appleOptions.context)
-      : transformedPrompt
+    const prompt = await applyAppleContextOptions(
+      options.prompt,
+      appleOptions.context
+    )
     const messages = this.prepareMessages(prompt)
     const tools = this.prepareTools(options.tools)
 
@@ -1051,7 +1049,9 @@ class AppleLLMChatLanguageModel implements AppleLanguageModel {
             topP: options.topP,
             topK: options.topK,
             tools,
-            providerOptions: appleOptions as unknown as Record<string, unknown>,
+            providerOptions: getNativeAppleProviderOptions(
+              appleOptions
+            ) as unknown as Record<string, unknown>,
             schema,
           })
         } catch (error) {

--- a/packages/apple-llm/src/ai-sdk.ts
+++ b/packages/apple-llm/src/ai-sdk.ts
@@ -477,6 +477,10 @@ function isToolRelatedMessage(message: LanguageModelV3Message) {
     return false
   }
 
+  if (!Array.isArray(message.content)) {
+    return false
+  }
+
   return message.content.some(
     (part) => part.type === 'tool-call' || part.type === 'tool-result'
   )

--- a/packages/apple-llm/src/index.ts
+++ b/packages/apple-llm/src/index.ts
@@ -1,4 +1,19 @@
-export { apple, createAppleProvider } from './ai-sdk'
+export {
+  apple,
+  createAppleProvider,
+  trimAppleMessagesForContext,
+} from './ai-sdk'
+export type {
+  AppleBuiltInTool,
+  AppleContextOptions,
+  AppleImagePersonalization,
+  AppleImageModelOptions,
+  AppleImageStyle,
+  AppleLanguageModelId,
+  AppleLanguageModelOptions,
+  AppleModelInfo,
+  AppleProviderOptions,
+} from './ai-sdk'
 export { default as AppleFoundationModels } from './AppleFoundationModels'
 export type { AppleLLMError, AppleLLMErrorCode } from './errors'
 export { AppleLLMErrorCodes } from './errors'

--- a/packages/apple-llm/src/index.ts
+++ b/packages/apple-llm/src/index.ts
@@ -1,6 +1,5 @@
 export type {
   AppleBuiltInTool,
-  AppleContextOptions,
   AppleImageModelOptions,
   AppleImagePersonalization,
   AppleImageStyle,
@@ -9,14 +8,9 @@ export type {
   AppleLanguageModelOptions,
   AppleModelInfo,
   AppleProviderOptions,
-  AppleSummarizeHistoryOptions,
   AppleToolDefinitionSet,
 } from './ai-sdk'
-export {
-  apple,
-  createAppleProvider,
-  trimAppleMessagesForContext,
-} from './ai-sdk'
+export { apple, createAppleProvider } from './ai-sdk'
 export { default as AppleFoundationModels } from './AppleFoundationModels'
 export type { AppleLLMError, AppleLLMErrorCode } from './errors'
 export { AppleLLMErrorCodes } from './errors'

--- a/packages/apple-llm/src/index.ts
+++ b/packages/apple-llm/src/index.ts
@@ -9,6 +9,7 @@ export type {
   AppleLanguageModelOptions,
   AppleModelInfo,
   AppleProviderOptions,
+  AppleSummarizeHistoryOptions,
   AppleToolDefinitionSet,
 } from './ai-sdk'
 export {

--- a/packages/apple-llm/src/index.ts
+++ b/packages/apple-llm/src/index.ts
@@ -1,18 +1,20 @@
-export {
-  apple,
-  createAppleProvider,
-  trimAppleMessagesForContext,
-} from './ai-sdk'
 export type {
   AppleBuiltInTool,
   AppleContextOptions,
-  AppleImagePersonalization,
   AppleImageModelOptions,
+  AppleImagePersonalization,
   AppleImageStyle,
+  AppleLanguageModel,
   AppleLanguageModelId,
   AppleLanguageModelOptions,
   AppleModelInfo,
   AppleProviderOptions,
+  AppleToolDefinitionSet,
+} from './ai-sdk'
+export {
+  apple,
+  createAppleProvider,
+  trimAppleMessagesForContext,
 } from './ai-sdk'
 export { default as AppleFoundationModels } from './AppleFoundationModels'
 export type { AppleLLMError, AppleLLMErrorCode } from './errors'

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,16 @@
+# React Native AI Utils
+
+Shared utilities for React Native AI SDK providers.
+
+```ts
+import { wrapLanguageModelWithHistory } from '@react-native-ai/utils'
+
+const modelWithHistory = wrapLanguageModelWithHistory(model, {
+  summarizeHistory: {
+    threshold: 5000,
+    model,
+  },
+  rollingWindowMessages: 12,
+  dropCompletedToolCalls: true,
+})
+```

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@react-native-ai/utils",
+  "version": "0.12.0",
+  "description": "Shared utilities for React Native AI SDK providers",
+  "main": "lib/commonjs/index",
+  "module": "lib/module/index",
+  "types": "lib/typescript/index.d.ts",
+  "react-native": "src/index",
+  "source": "src/index",
+  "files": [
+    "src",
+    "lib",
+    "!**/__tests__",
+    "!**/__fixtures__",
+    "!**/__mocks__",
+    "!**/.*",
+    "README.md"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/callstackincubator/ai#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/callstackincubator/ai.git"
+  },
+  "bugs": {
+    "url": "https://github.com/callstackincubator/ai/issues"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "author": "Mike Grabowski <grabbou@gmail.com>",
+  "scripts": {
+    "clean": "del-cli lib",
+    "typecheck": "tsc --noEmit",
+    "prepare": "bob build"
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "^3.0.5"
+  },
+  "react-native-builder-bob": {
+    "source": "src",
+    "output": "lib",
+    "targets": [
+      "commonjs",
+      "module",
+      [
+        "typescript",
+        {
+          "project": "tsconfig.build.json"
+        }
+      ]
+    ]
+  },
+  "keywords": [
+    "react-native",
+    "ai",
+    "sdk",
+    "utilities",
+    "history"
+  ]
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,340 @@
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Message,
+  LanguageModelV3Prompt,
+} from '@ai-sdk/provider'
+
+export interface HistorySummarizationOptions {
+  threshold: number
+  model: LanguageModelV3
+}
+
+export interface HistoryManagementOptions {
+  /**
+   * Summarize older messages when the prompt token count exceeds the threshold.
+   */
+  summarizeHistory?: HistorySummarizationOptions
+  /**
+   * Keep system messages and only the last N non-system messages.
+   */
+  rollingWindowMessages?: number
+  /**
+   * Remove completed tool-call/tool-result entries from older context.
+   */
+  dropCompletedToolCalls?: boolean
+}
+
+type LanguageModelLikeResult = Awaited<
+  ReturnType<LanguageModelV3['doGenerate']>
+>
+
+type TokenCountCapableLanguageModel = LanguageModelV3 & {
+  countTokens?: (text: string) => Promise<number>
+}
+
+type MessageContentPart = Extract<
+  LanguageModelV3Message['content'],
+  readonly unknown[]
+>[number]
+
+async function summarizePromptHistory(
+  prompt: LanguageModelV3Prompt,
+  threshold: number,
+  summarizerModel: LanguageModelV3
+): Promise<LanguageModelV3Prompt> {
+  if (threshold <= 0) {
+    return prompt
+  }
+
+  const promptTokenCount = await countPromptTokens(prompt, summarizerModel)
+
+  if (promptTokenCount <= threshold) {
+    return prompt
+  }
+
+  const systemMessages = prompt.filter((message) => message.role === 'system')
+  const conversationMessages = prompt.filter(
+    (message) => message.role !== 'system'
+  )
+
+  if (conversationMessages.length <= 2) {
+    return prompt
+  }
+
+  const latestMessage = conversationMessages[conversationMessages.length - 1]
+  const messagesToSummarize = conversationMessages.slice(0, -1)
+
+  if (messagesToSummarize.length === 0) {
+    return prompt
+  }
+
+  const summaryPrompt = buildSummaryPrompt(messagesToSummarize)
+  const summaryResult = await summarizerModel.doGenerate({
+    prompt: summaryPrompt,
+    maxOutputTokens: 400,
+  } as LanguageModelV3CallOptions)
+  const summaryText = extractTextFromGenerationResult(summaryResult).trim()
+
+  if (!summaryText) {
+    return prompt
+  }
+
+  return [
+    ...systemMessages,
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: `Summary of earlier conversation:\n${summaryText}`,
+        },
+      ],
+    },
+    latestMessage,
+  ]
+}
+
+async function countPromptTokens(
+  prompt: LanguageModelV3Prompt,
+  model: LanguageModelV3
+): Promise<number> {
+  const serializedPrompt = serializePromptForSummary(prompt)
+  const countTokens = (model as TokenCountCapableLanguageModel).countTokens
+
+  if (typeof countTokens === 'function') {
+    try {
+      return await countTokens(serializedPrompt)
+    } catch {
+      return estimateTokenCount(serializedPrompt)
+    }
+  }
+
+  return estimateTokenCount(serializedPrompt)
+}
+
+function estimateTokenCount(text: string): number {
+  if (!text.trim()) {
+    return 0
+  }
+
+  return Math.ceil(text.length / 4)
+}
+
+function buildSummaryPrompt(
+  messages: LanguageModelV3Prompt
+): LanguageModelV3Prompt {
+  return [
+    {
+      role: 'system',
+      content:
+        'Summarize the conversation history for continued assistant use. Preserve user goals, constraints, factual details, decisions, unresolved questions, and tool outcomes. Be concise and structured.',
+    },
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: serializePromptForSummary(messages),
+        },
+      ],
+    },
+  ]
+}
+
+function serializePromptForSummary(messages: LanguageModelV3Prompt): string {
+  return messages
+    .map((message) => {
+      const content = Array.isArray(message.content)
+        ? message.content.map(serializeMessageContentPart).join('\n')
+        : message.content
+
+      return `${message.role.toUpperCase()}: ${content}`
+    })
+    .join('\n\n')
+}
+
+function serializeKnownMessageContentPart(
+  part: MessageContentPart
+): string | undefined {
+  if (part.type === 'text') {
+    return part.text
+  }
+
+  if (part.type === 'file') {
+    return `[file:${part.mediaType}]`
+  }
+
+  if (part.type === 'tool-call') {
+    return `[tool-call:${part.toolName}] ${JSON.stringify(part.input)}`
+  }
+
+  if (part.type === 'tool-result') {
+    return `[tool-result:${part.toolName}] ${JSON.stringify(part.output)}`
+  }
+}
+
+function serializeMessageContentPart(part: MessageContentPart): string {
+  return serializeKnownMessageContentPart(part) ?? `[${part.type}]`
+}
+
+function extractTextFromGenerationResult(
+  result: LanguageModelLikeResult
+): string {
+  return result.content
+    .map((part) => (part.type === 'text' ? part.text : ''))
+    .join('')
+}
+
+export function trimMessagesForHistory(
+  messages: LanguageModelV3Prompt,
+  options: HistoryManagementOptions = {}
+): LanguageModelV3Prompt {
+  let nextMessages = messages
+
+  if (options.dropCompletedToolCalls) {
+    nextMessages = dropCompletedToolCallMessages(nextMessages)
+  }
+
+  if (options.rollingWindowMessages && options.rollingWindowMessages > 0) {
+    const systemMessages = nextMessages.filter(
+      (message) => message.role === 'system'
+    )
+    const conversationMessages = nextMessages.filter(
+      (message) => message.role !== 'system'
+    )
+    nextMessages = [
+      ...systemMessages,
+      ...conversationMessages.slice(-options.rollingWindowMessages),
+    ]
+  }
+
+  return nextMessages
+}
+
+function dropCompletedToolCallMessages(
+  messages: LanguageModelV3Prompt
+): LanguageModelV3Prompt {
+  const lastToolRelatedIndex = findLastIndex(messages, isToolRelatedMessage)
+
+  if (lastToolRelatedIndex === -1) {
+    return messages
+  }
+
+  let latestToolExchangeStartIndex = lastToolRelatedIndex
+  while (
+    latestToolExchangeStartIndex > 0 &&
+    isToolRelatedMessage(messages[latestToolExchangeStartIndex - 1])
+  ) {
+    latestToolExchangeStartIndex -= 1
+  }
+
+  return messages.filter((message, index) => {
+    if (index >= latestToolExchangeStartIndex) {
+      return true
+    }
+
+    return !isToolRelatedMessage(message)
+  })
+}
+
+function findLastIndex<T>(
+  items: T[],
+  predicate: (item: T, index: number) => boolean
+) {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index], index)) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function isToolRelatedMessage(message: LanguageModelV3Message) {
+  if (message.role === 'tool') {
+    return true
+  }
+
+  if (message.role !== 'assistant') {
+    return false
+  }
+
+  if (!Array.isArray(message.content)) {
+    return false
+  }
+
+  return message.content.some(
+    (part) => part.type === 'tool-call' || part.type === 'tool-result'
+  )
+}
+
+export async function applyHistoryManagement(
+  prompt: LanguageModelV3Prompt,
+  options: HistoryManagementOptions | undefined
+): Promise<LanguageModelV3Prompt> {
+  if (!options) {
+    return prompt
+  }
+
+  let nextPrompt = prompt
+
+  if (options.dropCompletedToolCalls) {
+    nextPrompt = trimMessagesForHistory(nextPrompt, {
+      dropCompletedToolCalls: true,
+    })
+  }
+
+  if (options.rollingWindowMessages && options.rollingWindowMessages > 0) {
+    nextPrompt = trimMessagesForHistory(nextPrompt, {
+      rollingWindowMessages: options.rollingWindowMessages,
+    })
+  }
+
+  if (options.summarizeHistory) {
+    nextPrompt = await summarizePromptHistory(
+      nextPrompt,
+      options.summarizeHistory.threshold,
+      options.summarizeHistory.model
+    )
+  }
+
+  return nextPrompt
+}
+
+export function wrapLanguageModelWithHistory<TModel extends LanguageModelV3>(
+  model: TModel,
+  options: HistoryManagementOptions
+): TModel {
+  return new Proxy(model, {
+    get(target, prop, receiver) {
+      if (prop === 'doGenerate') {
+        return async (callOptions: LanguageModelV3CallOptions) => {
+          const prompt = await applyHistoryManagement(
+            callOptions.prompt,
+            options
+          )
+          return target.doGenerate.call(target, {
+            ...callOptions,
+            prompt,
+          })
+        }
+      }
+
+      if (prop === 'doStream') {
+        return async (callOptions: LanguageModelV3CallOptions) => {
+          const prompt = await applyHistoryManagement(
+            callOptions.prompt,
+            options
+          )
+          return target.doStream.call(target, {
+            ...callOptions,
+            prompt,
+          })
+        }
+      }
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+}

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig",
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/website/src/docs/apple/generating.md
+++ b/website/src/docs/apple/generating.md
@@ -313,6 +313,23 @@ const apple = createAppleProvider({
 })
 ```
 
+For the Dynamic Profile-style fluent API, chain the history policies on the
+Apple language model:
+
+```typescript
+const summarizerModel = apple()
+
+const model = apple()
+  .summarizeHistory(5000, summarizerModel)
+  .rollingWindow(10)
+  .droppingCompletedToolCalls()
+```
+
+Fluent history modifiers are applied outside-in, matching Apple's utilities. In
+the example above, completed tool calls are dropped first, the rolling window is
+applied second, and older messages are summarized only if the remaining prompt
+still exceeds the threshold.
+
 You can also set them per request:
 
 ```typescript

--- a/website/src/docs/apple/generating.md
+++ b/website/src/docs/apple/generating.md
@@ -299,6 +299,9 @@ const info = await apple.getModelInfo()
 console.log(info.contextSize)
 ```
 
+For reusable history policies such as summarization, rolling windows, and
+completed tool-call pruning, use `@react-native-ai/utils`.
+
 Use low-level token counting as an estimate, not a fit guarantee:
 
 ```typescript

--- a/website/src/docs/apple/generating.md
+++ b/website/src/docs/apple/generating.md
@@ -299,59 +299,35 @@ const info = await apple.getModelInfo()
 console.log(info.contextSize)
 ```
 
-The provider exposes two light context policies inspired by Apple's Dynamic
-Profile history utilities:
+The provider exposes context policies inspired by Apple's Dynamic Profile
+history utilities:
 
 ```typescript
 import { createAppleProvider } from '@react-native-ai/apple'
 
+const summarizerModel = createAppleProvider().languageModel()
+
 const apple = createAppleProvider({
   context: {
+    summarizeHistory: {
+      threshold: 5000,
+      model: summarizerModel,
+    },
     rollingWindowMessages: 12,
     dropCompletedToolCalls: true,
   },
 })
 ```
 
-For the Dynamic Profile-style fluent API, chain the history policies on the
-Apple language model:
-
-```typescript
-const summarizerModel = apple()
-
-const model = apple()
-  .summarizeHistory(5000, summarizerModel)
-  .rollingWindow(10)
-  .droppingCompletedToolCalls()
-```
-
-Fluent history modifiers are applied outside-in, matching Apple's utilities. In
-the example above, completed tool calls are dropped first, the rolling window is
-applied second, and older messages are summarized only if the remaining prompt
-still exceeds the threshold.
-
-You can also set them per request:
-
-```typescript
-const result = await generateText({
-  model: apple(),
-  messages,
-  providerOptions: {
-    apple: {
-      context: {
-        rollingWindowMessages: 8,
-        dropCompletedToolCalls: true,
-      },
-    },
-  },
-})
-```
+History policies are applied in a fixed order: completed tool calls are dropped
+first, the rolling window is applied second, and older messages are summarized
+only if the remaining prompt still exceeds the threshold.
 
 `rollingWindowMessages` keeps system messages and the last N non-system
 messages. `dropCompletedToolCalls` removes older completed tool-call/tool-result
-entries while keeping the newest tool-related exchange. For larger apps,
-summarize older turns at the application layer and include the summary as a
-system or user message.
+entries while keeping the newest tool-related exchange. `summarizeHistory`
+replaces older conversation turns with a generated summary once the prompt token
+count exceeds the configured threshold.
 
 Use low-level token counting as an estimate, not a fit guarantee:
 

--- a/website/src/docs/apple/generating.md
+++ b/website/src/docs/apple/generating.md
@@ -299,36 +299,6 @@ const info = await apple.getModelInfo()
 console.log(info.contextSize)
 ```
 
-The provider exposes context policies inspired by Apple's Dynamic Profile
-history utilities:
-
-```typescript
-import { createAppleProvider } from '@react-native-ai/apple'
-
-const summarizerModel = createAppleProvider().languageModel()
-
-const apple = createAppleProvider({
-  context: {
-    summarizeHistory: {
-      threshold: 5000,
-      model: summarizerModel,
-    },
-    rollingWindowMessages: 12,
-    dropCompletedToolCalls: true,
-  },
-})
-```
-
-History policies are applied in a fixed order: completed tool calls are dropped
-first, the rolling window is applied second, and older messages are summarized
-only if the remaining prompt still exceeds the threshold.
-
-`rollingWindowMessages` keeps system messages and the last N non-system
-messages. `dropCompletedToolCalls` removes older completed tool-call/tool-result
-entries while keeping the newest tool-related exchange. `summarizeHistory`
-replaces older conversation turns with a generated summary once the prompt token
-count exceeds the configured threshold.
-
 Use low-level token counting as an estimate, not a fit guarantee:
 
 ```typescript

--- a/website/src/docs/apple/generating.md
+++ b/website/src/docs/apple/generating.md
@@ -93,7 +93,7 @@ mapped to Apple Foundation Models.
 
 ## Availability And Model Info
 
-Check availability before showing Apple-only UI:
+Check availability before using the Apple Intelligence wrapper backend or showing Apple-only UI:
 
 ```typescript
 import { apple } from '@react-native-ai/apple'

--- a/website/src/docs/apple/generating.md
+++ b/website/src/docs/apple/generating.md
@@ -1,470 +1,344 @@
 # Generating
 
-You can generate response using Apple Foundation Models with the Vercel AI SDK's `generateText` or `generateObject` function.
+Use `@react-native-ai/apple` with the Vercel AI SDK to call Apple Foundation
+Models from React Native. The provider keeps the common text, object,
+streaming, tool, and image APIs aligned with AI SDK v5, and exposes a small
+Apple-specific surface for runtime model information and Apple-only options.
 
 ## Requirements
 
-- **iOS 26+** - Apple Foundation Models is available in iOS 26 or later
-- **Apple Intelligence enabled device** - Device must support Apple Intelligence
+- iOS 26+ for Apple Foundation Models text generation.
+- iOS 26.4+ for token counting and Image Playground image generation.
+- iOS 27+ for multimodal image prompts, Private Cloud Compute language models,
+  Dynamic Profiles, and Vision built-in tools.
+- An Apple Intelligence-capable device with Apple Intelligence enabled.
+- React Native New Architecture.
+
+Some Apple Intelligence symbols are SDK-gated as well as OS-gated. If you build
+with an older Xcode SDK that does not expose a newer Apple API, the provider
+keeps that feature unavailable instead of failing native compilation.
 
 ## Text Generation
 
 ```typescript
-import { apple } from '@react-native-ai/apple';
-import { generateText } from 'ai';
+import { apple } from '@react-native-ai/apple'
+import { generateText } from 'ai'
 
 const result = await generateText({
   model: apple(),
-  prompt: 'Explain quantum computing in simple terms'
-});
+  prompt: 'Explain quantum computing in simple terms.',
+})
+
+console.log(result.text)
 ```
+
+Configure the model with the normal AI SDK generation options:
+
+```typescript
+const result = await generateText({
+  model: apple(),
+  prompt: 'Write a concise product announcement.',
+  temperature: 0.6,
+  maxTokens: 300,
+  topP: 0.9,
+})
+```
+
+Do not pass both `topP` and `topK` in the same request. Apple Foundation Models
+supports one sampling strategy at a time.
 
 ## Streaming
 
 ```typescript
-import { streamText } from 'ai';
-import { apple } from '@react-native-ai/apple';
-
-const { textStream } = await streamText({
-  model: apple(),
-  prompt: 'Write me a short essay on the meaning of life'
-});
-
-for await (const delta of textStream) {
-  console.log(delta);
-}
-```
-
-> [!NOTE]
-> Streaming objects is currently not supported.
-
-## Structured Output
-
-Generate structured data that conforms to a specific schema:
-
-```typescript
-import { generateObject } from 'ai';
-import { apple } from '@react-native-ai/apple';
-import { z } from 'zod';
-
-const schema = z.object({
-  name: z.string(),
-  age: z.number().int().min(0).max(150),
-  email: z.string().email(),
-  occupation: z.string()
-});
-
-const result = await generateObject({
-  model: apple(),
-  prompt: 'Generate a user profile for a software developer',
-  schema
-});
-
-console.log(result.object);
-// { name: string, age: number, email: string, occupation: string }
-```
-
-## Tool Calling
-
-Enable Apple Foundation Models to use custom tools in your React Native applications.
-
-### Important Apple-Specific Behavior
-
-Tools are executed by Apple, not the Vercel AI SDK, which means:
-
-- **No AI SDK callbacks**: `maxSteps`, `onStepStart`, and `onStepFinish` will not be executed
-- **Pre-register all tools**: You must pass all tools to `createAppleProvider` upfront
-- **Empty toolCallId**: Apple doesn't provide tool call IDs, so they will be empty strings
-
-### Setup
-
-All tools must be registered ahead of time with Apple provider. To do so, you must create one by calling `createAppleProvider`:
-
-```typescript
-import { createAppleProvider } from '@react-native-ai/apple';
-import { generateText, tool } from 'ai';
-import { z } from 'zod';
-
-const getWeather = tool({
-  description: 'Get current weather information',
-  inputSchema: z.object({
-    city: z.string()
-  }),
-  execute: async ({ city }) => {
-    return `Weather in ${city}: Sunny, 25°C`;
-  }
-});
-
-const apple = createAppleProvider({
-  availableTools: {
-    getWeather
-  }
-});
-```
-
-If you want to change the tools at runtime, you can do it as follows:
-
-```typescript
-const apple = createAppleProvider({
-  availableTools: {
-    getWeather
-  }
-});
-const model = apple();
-
-model.updateTools({
-  getWeather,
-  getDate
-});
-```
-
-### Basic Tool Usage
-
-Then, generate output like with any other Vercel AI SDK provider:
-
-```typescript
-const result = await generateText({
-  model: apple(),
-  prompt: 'What is the weather in Paris?',
-  tools: {
-    getWeather
-  }
-});
-```
-
-### Inspecting Tool Calls
-
-You can inspect tool calls and their results after generation:
-
-```typescript
-const result = await generateText({
-  model: apple(),
-  prompt: 'What is the weather in Paris?',
-  tools: { getWeather }
-});
-
-// Inspect tool calls made during generation
-console.log(result.toolCalls);
-// Example: [{ toolCallId: '<< redacted >>', toolName: 'getWeather', input: '{"city":"Paris"}' }]
-
-// Inspect tool results returned
-console.log(result.toolResults);  
-// Example: [{ toolCallId: '<< redacted >>', toolName: 'getWeather', result: 'Weather in Paris: Sunny, 25°C' }]
-```
-
-### Tool calling with structured output
-
-You can also use [`experimental_output`](https://v5.ai-sdk.dev/docs/reference/ai-sdk-core/generate-text#experimental_output) to generate structured output with `generateText`. This is useful when you want to perform tool calls at the same time.
-
-```typescript
-const response = await generateText({
-  model: apple(),
-  system: `Help the person with getting weather information.`,
-  prompt: 'What is the weather in Wroclaw?',
-  tools: {
-    getWeather,
-  },
-  experimental_output: Output.object({
-    schema: z.object({
-      weather: z.string(),
-      city: z.string(),
-    }),
-  }),
-})
-```
-
-### Supported features
-
-We aim to cover most of the OpenAI supported formats, including the following:
-
-- **Objects**: `z.object({})` with nested properties
-- **Arrays**: `z.array()` with `minItems` and `maxItems` constraints
-- **Strings**: `z.string()`
-- **Numbers**: `z.number()` with `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`
-- **Booleans**: `z.boolean()`
-- **Enums**: `z.enum([])` for string and number values
-
-The following features are currently not supported due to underlying model limitations:
-
-- **String formats**: `email()`, `url()`, `uuid()`, `datetime()` etc.
-- **Regular expressions**: Due to a
-- **Unions**: `z.union()`, `z.discriminatedUnion()`
-
-## Availability Check
-
-Always check if Apple Intelligence is available before using the provider:
-
-```typescript
-import { apple } from '@react-native-ai/apple';
-
-if (!apple.isAvailable()) {
-  // Handle fallback logic
-  return;
-}
-```
-
-## Context Window
-
-Apple Foundation Models have a fixed context window of 4096 tokens. This limit applies to the full request context, including system instructions, previous conversation messages, tool definitions, schemas, and the current user prompt.
-
-The `maxTokens` option only limits how many tokens the model can generate in its response. It does not increase the available context window or reserve enough room for a long prompt.
-
-If the full context is too large, Apple may fail generation with a context-window overflow error. The provider does not automatically estimate tokens, remove messages from your prompt, or retry the request, because token estimates can vary by language and different apps need different memory strategies. Handle this at the application level by catching the error and choosing the recovery behavior that fits your product:
-
-- Start a new conversation without the previous transcript, which is Apple's recommended baseline after this error
-- Keep a sliding window of recent messages
-- Summarize older messages and include the summary instead of the full transcript
-- Ask the user to shorten the prompt or start a new chat
-
-```typescript
-import {
-  AppleLLMErrorCodes,
-  type AppleLLMError,
-  apple,
-} from '@react-native-ai/apple';
-import { generateText } from 'ai';
-
-try {
-  const result = await generateText({
-    model: apple(),
-    messages
-  });
-} catch (error) {
-  const appleError = error as AppleLLMError;
-
-  if (appleError.code === AppleLLMErrorCodes.ContextWindowExceeded) {
-    // Apply your app's recovery strategy here.
-    // For example: retry with fewer messages or start a new chat.
-  }
-
-  throw error;
-}
-```
-
-For streaming calls, use `fullStream` when you need to inspect provider error parts:
-
-```typescript
-import {
-  AppleLLMErrorCodes,
-  type AppleLLMError,
-  apple,
-} from '@react-native-ai/apple';
-import { streamText } from 'ai';
+import { apple } from '@react-native-ai/apple'
+import { streamText } from 'ai'
 
 const result = streamText({
   model: apple(),
-  messages
-});
-
-for await (const part of result.fullStream) {
-  if (part.type === 'error') {
-    const error = part.error as AppleLLMError;
-
-    if (error.code === AppleLLMErrorCodes.ContextWindowExceeded) {
-      // Apply your app's recovery strategy here.
-    }
-  }
-}
-```
-
-If you only consume `textStream`, pass `onError` to `streamText`. The AI SDK does not emit error parts through the text-only stream, so capture the error there and handle it after the stream finishes:
-
-```typescript
-import {
-  AppleLLMErrorCodes,
-  type AppleLLMError,
-  apple,
-} from '@react-native-ai/apple';
-import { streamText } from 'ai';
-
-let streamError: unknown;
-const result = streamText({
-  model: apple(),
-  messages,
-  onError: ({ error }) => {
-    streamError = error;
-  },
-});
-
-for await (const delta of result.textStream) {
-  console.log(delta);
-}
-
-if (streamError) {
-  const error = streamError as AppleLLMError;
-
-  if (error.code === AppleLLMErrorCodes.ContextWindowExceeded) {
-    // Apply your app's recovery strategy here.
-  }
-
-  throw streamError;
-}
-```
-
-## Public Error Codes
-
-Apple Foundation Models exposes a deliberate public error-code surface through `AppleLLMError.code`. Use `error.code` for application control flow and treat `error.message` as display/debug text rather than a compatibility contract.
-
-Only documented `AppleLLMErrorCodes.*` values are stable:
-
-- `AppleLLMErrorCodes.ModelUnavailable` / `MODEL_UNAVAILABLE`
-- `AppleLLMErrorCodes.UnsupportedOS` / `UNSUPPORTED_OS`
-- `AppleLLMErrorCodes.GenerationError` / `GENERATION_ERROR`
-- `AppleLLMErrorCodes.InvalidMessage` / `INVALID_MESSAGE`
-- `AppleLLMErrorCodes.ConflictingSamplingMethods` / `CONFLICTING_SAMPLING_METHODS`
-- `AppleLLMErrorCodes.InvalidSchema` / `INVALID_SCHEMA`
-- `AppleLLMErrorCodes.ToolCallError` / `TOOL_CALL_ERROR`
-- `AppleLLMErrorCodes.UnknownToolCallError` / `UNKNOWN_TOOL_CALL_ERROR`
-- `AppleLLMErrorCodes.ContextWindowExceeded` / `CONTEXT_WINDOW_EXCEEDED`
-
-These codes mean:
-
-- `MODEL_UNAVAILABLE`: Apple Intelligence is unavailable on the current device or configuration.
-- `UNSUPPORTED_OS`: the current runtime does not support the required Apple Foundation Models API.
-- `GENERATION_ERROR`: Foundation Models generation failed for an uncategorized provider-side reason.
-- `INVALID_MESSAGE`: the prompt/message structure is invalid for this provider.
-- `CONFLICTING_SAMPLING_METHODS`: both `topP` and `topK` were provided.
-- `INVALID_SCHEMA`: the provided schema or tool schema cannot be used by Apple Foundation Models.
-- `TOOL_CALL_ERROR`: a tool execution failed.
-- `UNKNOWN_TOOL_CALL_ERROR`: tool execution finished in an unusable or unexpected state.
-- `CONTEXT_WINDOW_EXCEEDED`: the request exceeded the model context window.
-
-Errors that do not have a recognized public Apple LLM code may still be thrown, but they are plain `Error` values and are not part of the stable Apple provider API.
-
-### Handling `generateText` errors
-
-```typescript
-import {
-  AppleLLMErrorCodes,
-  type AppleLLMError,
-  apple,
-} from '@react-native-ai/apple';
-import { generateText } from 'ai';
-
-try {
-  await generateText({
-    model: apple(),
-    messages,
-  })
-} catch (error) {
-  if (
-    error instanceof Error &&
-    'code' in error &&
-    error.code === AppleLLMErrorCodes.ModelUnavailable
-  ) {
-    // Show fallback UI or disable Apple-specific features.
-  }
-
-  throw error
-}
-```
-
-### Handling streaming errors with `fullStream`
-
-```typescript
-import {
-  AppleLLMErrorCodes,
-  type AppleLLMError,
-  apple,
-} from '@react-native-ai/apple';
-import { streamText } from 'ai';
-
-const result = streamText({
-  model: apple(),
-  messages,
-})
-
-for await (const part of result.fullStream) {
-  if (
-    part.type === 'error' &&
-    part.error instanceof Error &&
-    'code' in part.error &&
-    part.error.code === AppleLLMErrorCodes.InvalidSchema
-  ) {
-    // Handle invalid schema input.
-  }
-}
-```
-
-### Handling streaming errors with `textStream` and `onError`
-
-```typescript
-import {
-  AppleLLMErrorCodes,
-  type AppleLLMError,
-  apple,
-} from '@react-native-ai/apple';
-import { streamText } from 'ai';
-
-let streamError: unknown
-const result = streamText({
-  model: apple(),
-  messages,
-  onError: ({ error }) => {
-    streamError = error
-  },
+  prompt: 'Draft a short release note.',
 })
 
 for await (const delta of result.textStream) {
   console.log(delta)
 }
+```
 
-if (
-  streamError instanceof Error &&
-  'code' in streamError &&
-  streamError.code === AppleLLMErrorCodes.ToolCallError
-) {
-  // Handle tool failure.
+Streaming structured objects are not currently supported by this provider.
+
+## Structured Output
+
+Use `generateObject` when you want Apple guided generation through the AI SDK:
+
+```typescript
+import { apple } from '@react-native-ai/apple'
+import { generateObject } from 'ai'
+import { z } from 'zod'
+
+const result = await generateObject({
+  model: apple(),
+  prompt: 'Create a compact user profile for a software developer.',
+  schema: z.object({
+    name: z.string(),
+    role: z.string(),
+    seniority: z.enum(['junior', 'mid', 'senior']),
+  }),
+})
+
+console.log(result.object)
+```
+
+Supported schema shapes include objects, arrays, strings, numbers, booleans,
+and enums. String formats, regular expressions, and unions are not currently
+mapped to Apple Foundation Models.
+
+## Availability And Model Info
+
+Check availability before showing Apple-only UI:
+
+```typescript
+import { apple } from '@react-native-ai/apple'
+
+if (!apple.isAvailable()) {
+  // Show fallback UI or use another provider.
 }
 ```
 
-## Available Options
-
-Configure model behavior with generation options:
-
-- `temperature` (0-1): Controls randomness. Higher values = more creative, lower = more focused
-- `maxTokens`: Maximum number of tokens to generate
-- `topP` (0-1): Nucleus sampling threshold
-- `topK`: Top-K sampling parameter
-
-You can pass selected options with either `generateText` or `generateObject` as follows:
+For capability-aware UI, ask native for the active model metadata:
 
 ```typescript
-import { apple } from '@react-native-ai/apple';
-import { generateText } from 'ai';
+const info = await apple.getModelInfo({ locale: 'en-US' })
+
+console.log(info.isAvailable)
+console.log(info.contextSize)
+console.log(info.supportsImagePrompts)
+console.log(info.supportsVisionTools)
+```
+
+`getModelInfo` returns availability, locale support, supported languages,
+context size when Apple exposes it, and feature flags for token counting,
+image prompts, Private Cloud Compute, Dynamic Profiles, and Vision built-in
+tools.
+
+## Private Cloud Compute
+
+The default `apple()` model uses `SystemLanguageModel.default`. On iOS 27 and
+newer, choose Apple's Private Cloud Compute language model with provider
+options:
+
+```typescript
+const result = await generateText({
+  model: apple(),
+  prompt: 'Analyze this longer task with more reasoning.',
+  providerOptions: {
+    apple: {
+      model: 'private-cloud-compute',
+    },
+  },
+})
+```
+
+You can also create a provider with a default model:
+
+```typescript
+import { createAppleProvider } from '@react-native-ai/apple'
+
+const apple = createAppleProvider({
+  model: 'private-cloud-compute',
+})
+```
+
+Call `apple.getModelInfo({ model: 'private-cloud-compute' })` before enabling
+this path. It requires iOS 27 APIs and may report quota usage.
+
+## Image Prompts
+
+On iOS 27 and newer, Apple Foundation Models can analyze images alongside text
+prompts. Pass images through the AI SDK message format:
+
+```typescript
+import { apple } from '@react-native-ai/apple'
+import { generateText } from 'ai'
 
 const result = await generateText({
   model: apple(),
-  prompt: 'Write a creative story',
-  temperature: 0.8,
-  maxTokens: 500,
-  topP: 0.9,
-});
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Describe this image for accessibility.' },
+        {
+          type: 'file',
+          mediaType: 'image/jpeg',
+          data: 'file:///path/to/photo.jpg',
+        },
+      ],
+    },
+  ],
+})
+
+console.log(result.text)
 ```
 
-## Direct API Access
+The provider accepts local file URLs, absolute file paths, base64 image data,
+and image data URLs. Remote HTTP URLs are not sent directly to Apple; download
+them first and pass a local file URL or base64 payload.
 
-For advanced use cases, you can access the native Apple Foundation Models API directly:
+Image attachments are currently supported on the final user prompt. Passing
+image parts on older OS versions throws `AppleLLMErrorCodes.UnsupportedOS`.
 
-### AppleFoundationModels
+## Image Generation
 
-```tsx
-import { AppleFoundationModels } from '@react-native-ai/apple'
+Use the AI SDK image API with Apple's Image Playground framework:
 
-// Check if Apple Intelligence is available
-const isAvailable = AppleFoundationModels.isAvailable()
+```typescript
+import { apple } from '@react-native-ai/apple'
+import { generateImage } from 'ai'
 
-// Generate text responses
-const messages = [{ role: 'user', content: 'Hello' }]
-const options = { temperature: 0.7, maxTokens: 100 }
+const result = await generateImage({
+  model: apple.imageModel({
+    style: 'illustration',
+    personalization: 'disabled',
+  }),
+  prompt: 'A friendly robot watering balcony herbs',
+  n: 1,
+})
 
-const result = await AppleFoundationModels.generateText(messages, options)
+const base64Png = result.images[0].base64
 ```
 
-On iOS 26.4 and newer, you can also count the number of tokens in a string
-before sending it to the model:
+The provider uses `ImageCreator` on iOS 26.4 and newer and returns PNG images.
+Supported styles are `animation`, `illustration`, and `sketch`; iOS 27 adds
+`any`, `emoji`, and `externalProvider`. Apple supports at most one source image
+concept for generation, so pass no more than one file. Personalization is
+applied when the app is built with an SDK that exposes `ImagePlaygroundOptions`.
 
-```tsx
+Per-call Apple options can override model defaults:
+
+```typescript
+const result = await generateImage({
+  model: apple.imageModel(),
+  prompt: 'A hand-drawn icon for a notes app',
+  providerOptions: {
+    apple: {
+      style: 'sketch',
+      personalization: 'disabled',
+    },
+  },
+})
+```
+
+## Tool Calling
+
+Apple executes tools inside the Foundation Models session. Register JavaScript
+tools up front so native can call them by name:
+
+```typescript
+import { createAppleProvider } from '@react-native-ai/apple'
+import { generateText, tool } from 'ai'
+import { z } from 'zod'
+
+const getWeather = tool({
+  description: 'Get current weather information.',
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  execute: async ({ city }) => `Weather in ${city}: sunny`,
+})
+
+const apple = createAppleProvider({
+  availableTools: {
+    getWeather,
+  },
+})
+
+const result = await generateText({
+  model: apple(),
+  prompt: 'What is the weather in Paris?',
+  tools: {
+    getWeather,
+  },
+})
+```
+
+Important Apple-specific behavior:
+
+- Tool calls are provider-executed, so AI SDK step callbacks such as
+  `maxSteps`, `onStepStart`, and `onStepFinish` do not run for native Apple
+  tool execution.
+- Apple does not provide stable tool call IDs; the provider returns empty IDs.
+- You can update the registered tools on a model instance with
+  `model.updateTools(...)` before generation.
+
+## Vision Built-In Tools
+
+iOS 27 adds Foundation Models integration with Vision's OCR and barcode tools.
+Enable them through Apple provider options:
+
+```typescript
+const result = await generateText({
+  model: apple(),
+  messages,
+  providerOptions: {
+    apple: {
+      builtInTools: ['ocr', 'barcode'],
+    },
+  },
+})
+```
+
+These tools require iOS 27. On older systems the provider throws
+`AppleLLMErrorCodes.UnsupportedOS`.
+
+## Context Window
+
+Apple's available context depends on the model and OS version. Prefer runtime
+metadata over hard-coded values:
+
+```typescript
+const info = await apple.getModelInfo()
+console.log(info.contextSize)
+```
+
+The provider exposes two light context policies inspired by Apple's Dynamic
+Profile history utilities:
+
+```typescript
+import { createAppleProvider } from '@react-native-ai/apple'
+
+const apple = createAppleProvider({
+  context: {
+    rollingWindowMessages: 12,
+    dropCompletedToolCalls: true,
+  },
+})
+```
+
+You can also set them per request:
+
+```typescript
+const result = await generateText({
+  model: apple(),
+  messages,
+  providerOptions: {
+    apple: {
+      context: {
+        rollingWindowMessages: 8,
+        dropCompletedToolCalls: true,
+      },
+    },
+  },
+})
+```
+
+`rollingWindowMessages` keeps system messages and the last N non-system
+messages. `dropCompletedToolCalls` removes older completed tool-call/tool-result
+entries while keeping the newest tool-related exchange. For larger apps,
+summarize older turns at the application layer and include the summary as a
+system or user message.
+
+Use low-level token counting as an estimate, not a fit guarantee:
+
+```typescript
 import { AppleFoundationModels } from '@react-native-ai/apple'
 
 const tokenCount = await AppleFoundationModels.countTokens(
@@ -472,10 +346,99 @@ const tokenCount = await AppleFoundationModels.countTokens(
 )
 ```
 
-Token counting is useful for estimating prompt size, but it is not a complete
-guarantee that a generation request will fit in the model context window. The
-full context also includes instructions, previous messages in the transcript,
-tools, schemas, and generated output.
+The full request also includes instructions, tool definitions, schema text,
+attachments, and generated output budget. If Apple reports a context overflow,
+trim or summarize and retry.
 
-The maximum context window size for Apple's Foundation models is 4096 tokens
-per session. More information can be found [here](https://developer.apple.com/documentation/technotes/tn3193-managing-the-on-device-foundation-model-s-context-window).
+## Error Handling
+
+Use public error codes for app control flow:
+
+```typescript
+import {
+  AppleLLMErrorCodes,
+  type AppleLLMError,
+  apple,
+} from '@react-native-ai/apple'
+import { generateText } from 'ai'
+
+try {
+  await generateText({
+    model: apple(),
+    messages,
+  })
+} catch (error) {
+  const appleError = error as AppleLLMError
+
+  if (appleError.code === AppleLLMErrorCodes.ContextWindowExceeded) {
+    // Retry with a smaller transcript or a summary.
+  }
+
+  throw error
+}
+```
+
+For streaming, inspect `fullStream` when you need provider error parts:
+
+```typescript
+import {
+  AppleLLMErrorCodes,
+  type AppleLLMError,
+  apple,
+} from '@react-native-ai/apple'
+import { streamText } from 'ai'
+
+const result = streamText({
+  model: apple(),
+  messages,
+})
+
+for await (const part of result.fullStream) {
+  if (part.type === 'error') {
+    const error = part.error as AppleLLMError
+
+    if (error.code === AppleLLMErrorCodes.ModelUnavailable) {
+      // Show fallback UI.
+    }
+  }
+}
+```
+
+Stable public codes are:
+
+- `MODEL_UNAVAILABLE`
+- `UNSUPPORTED_OS`
+- `GENERATION_ERROR`
+- `INVALID_MESSAGE`
+- `CONFLICTING_SAMPLING_METHODS`
+- `INVALID_SCHEMA`
+- `TOOL_CALL_ERROR`
+- `UNKNOWN_TOOL_CALL_ERROR`
+- `CONTEXT_WINDOW_EXCEEDED`
+
+## Direct Native API
+
+Prefer the AI SDK models for generation. Use `AppleFoundationModels` only when
+you need low-level native access:
+
+```typescript
+import { AppleFoundationModels } from '@react-native-ai/apple'
+
+const info = await AppleFoundationModels.getModelInfo('en-US', 'system')
+const tokens = await AppleFoundationModels.countTokens('A short prompt')
+const result = await AppleFoundationModels.generateText(
+  [{ role: 'user', content: 'Hello' }],
+  { temperature: 0.7, maxTokens: 100 }
+)
+```
+
+Low-level `generateImages` is available for advanced callers, but
+`apple.imageModel()` is the recommended Image Playground integration because it
+matches the AI SDK image API.
+
+## Apple Documentation
+
+- [Apple Intelligence](https://developer.apple.com/apple-intelligence/)
+- [Foundation Models](https://developer.apple.com/documentation/FoundationModels)
+- [Image Playground](https://developer.apple.com/documentation/imageplayground)
+- [Managing the on-device foundation model's context window](https://developer.apple.com/documentation/technotes/tn3193-managing-the-on-device-foundation-model-s-context-window)


### PR DESCRIPTION
Related PR - [#215](https://github.com/callstackincubator/ai/pull/215)

## Summary

Builds on the WWDC26 Apple Intelligence API work from #215 and finishes the JS-facing history management API for `@react-native-ai/apple`.

PR #215 added the broader Apple Intelligence surface, including Apple provider options, model info APIs, iOS 27 Private Cloud Compute support, image prompts, Image Playground generation, Vision built-in tools, and lower-level native helpers. It also introduced context/history utilities internally.

This change exposes those history management utilities as fluent AI SDK model wrappers so consumers can compose Apple history behavior directly from JS:

```ts
const summarizerModel = apple()

const model = apple()
  .summarizeHistory(5000, summarizerModel)
  .rollingWindow(10)
  .droppingCompletedToolCalls()
```

It also adds demo app controls for testing the behavior without replacing the existing basic chat flow.

## Changes

- Add fluent Apple model wrappers for:
  - `summarizeHistory(threshold, model)`
  - `rollingWindow(entries)`
  - `droppingCompletedToolCalls()`
- Apply history transforms before both `doGenerate` and `doStream`
- Preserve dynamic tool configuration when wrapping Apple language models
- Keep transform ordering aligned with Apple-style chained history utilities
- Export Apple language model types needed by consumers and the demo app
- Add Apple History Demo controls to the Expo example app
- Add settings for enabling history management, rolling window size, and summary threshold
- Preserve the existing basic chat demo behavior when the history demo is disabled
- Document the fluent history management API in the package README and website docs
- Include #215’s WWDC26 Apple Intelligence API work as the base for this follow-up

## Testing

- Ran `bun run --filter='@react-native-ai/apple' typecheck`
- Ran `bun run --filter='@react-native-ai/example' typecheck`
- Ran `bun lint`
- Ran `git diff --check`
- Tested manually in the Expo demo app on iOS 26.5 with Apple Intelligence selected
- Verified basic chat still works with the Apple History Demo disabled
- Verified history transforms run when the Apple History Demo is enabled
- Verified rolling window trims older conversation entries while preserving system context
- Verified summarization applies when the prompt exceeds a low test threshold
- Verified completed tool-call pruning with a synthetic tool-call history path
- Removed temporary debug logging after validation