### PR TITLE
feat: docs for ADK & default to gemini-nano in short provider factory syntax

### DIFF
--- a/packages/adk/README.md
+++ b/packages/adk/README.md
@@ -1,6 +1,6 @@
 # ADK Provider for Vercel AI SDK
 
-A Vercel AI SDK provider for [Google's Agent Development Kit (ADK)](https://developer.android.com/ai/adk) on Android. Use Gemini Nano and cloud Gemini on Android with tool calling, multi-turn sessions, and optional on-device Gemini Nano inference.
+A Vercel AI SDK provider for [Google's Agent Development Kit (ADK)](https://developer.android.com/ai/adk) on Android. Use on-device Gemini Nano or cloud Gemini with tool calling and multi-turn sessions.
 
 **Requirements:**
 

--- a/packages/adk/README.md
+++ b/packages/adk/README.md
@@ -99,6 +99,7 @@ import { generateText } from 'ai'
 
 const adk = createAdkProvider({
   apiKey: process.env.GOOGLE_API_KEY,
+  modelType: 'gemini',
   modelName: 'gemini-2.5-flash',
   instruction: 'You are a helpful assistant.',
 })

--- a/packages/adk/README.md
+++ b/packages/adk/README.md
@@ -1,6 +1,6 @@
 # ADK Provider for Vercel AI SDK
 
-A Vercel AI SDK provider for [Google's Agent Development Kit (ADK)](https://developer.android.com/ai/adk) on Android. Build AI agents with tool calling, multi-turn sessions, and optional on-device Gemini Nano inference.
+A Vercel AI SDK provider for [Google's Agent Development Kit (ADK)](https://developer.android.com/ai/adk) on Android. Use Gemini Nano and cloud Gemini on Android with tool calling, multi-turn sessions, and optional on-device Gemini Nano inference.
 
 **Requirements:**
 
@@ -115,10 +115,10 @@ const { text } = await generateText({
 
 Gemini Nano has two separate availability checks:
 
-| API                                  | Label                 | Question                                   |
-| ------------------------------------ | --------------------- | ------------------------------------------ |
-| `adk.isNanoSupported()`              | **Device capability** | Can this device ever run Nano?             |
-| `adk.isAvailable('genai-nano')`      | **Runtime readiness** | Can I call `prepareNano()` / generate now? |
+| API                             | Label                 | Question                                   |
+| ------------------------------- | --------------------- | ------------------------------------------ |
+| `adk.isNanoSupported()`         | **Device capability** | Can this device ever run Nano?             |
+| `adk.isAvailable('genai-nano')` | **Runtime readiness** | Can I call `prepareNano()` / generate now? |
 
 If `isNanoSupported()` is `false`, `isAvailable('genai-nano')` is also `false`.
 

--- a/packages/adk/android/src/main/java/com/callstack/ai/adk/AdkAgentRunner.kt
+++ b/packages/adk/android/src/main/java/com/callstack/ai/adk/AdkAgentRunner.kt
@@ -393,8 +393,8 @@ class AdkAgentRunner(
         name = config.getString("name") ?: "react_native_adk_agent",
         description = config.getString("description") ?: "",
         instruction = config.getString("instruction"),
-        modelType = model.getString("type") ?: "gemini",
-        modelName = model.getString("name") ?: "gemini-2.5-flash",
+        modelType = model.getString("type") ?: "genai-nano",
+        modelName = model.getString("name") ?: "gemini-nano",
         apiKey = model.getString("apiKey"),
       )
     }

--- a/packages/adk/src/ai-sdk.ts
+++ b/packages/adk/src/ai-sdk.ts
@@ -78,7 +78,7 @@ export function createAdkProvider(
   }
   provider.languageModel = createLanguageModel
   provider.isNanoSupported = () => checkNanoSupported()
-  provider.isAvailable = async (modelType: AdkModelType = 'gemini') => {
+  provider.isAvailable = async (modelType: AdkModelType = 'genai-nano') => {
     if (modelType === 'genai-nano' && !(await checkNanoSupported())) {
       return false
     }
@@ -209,8 +209,8 @@ class AdkChatLanguageModel implements LanguageModelV3 {
   private nanoPreparePromise: Promise<void> | null = null
 
   constructor(options: AdkProviderOptions) {
-    const modelType = options.modelType ?? 'gemini'
-    this.modelId = options.modelName ?? 'gemini-2.5-flash'
+    const modelType = options.modelType ?? 'genai-nano'
+    this.modelId = options.modelName ?? 'gemini-nano'
     this.agentConfig = {
       name: options.name ?? 'react_native_adk_agent',
       description: options.description ?? 'React Native ADK agent',

--- a/website/src/docs/_meta.json
+++ b/website/src/docs/_meta.json
@@ -23,6 +23,13 @@
   },
   {
     "type": "dir",
+    "name": "adk",
+    "label": "ADK",
+    "collapsible": true,
+    "collapsed": false
+  },
+  {
+    "type": "dir",
     "name": "llama",
     "label": "Llama",
     "collapsible": true,

--- a/website/src/docs/adk/_meta.json
+++ b/website/src/docs/adk/_meta.json
@@ -1,0 +1,4 @@
+[
+  { "type": "file", "name": "getting-started", "label": "Getting Started" },
+  { "type": "file", "name": "generating", "label": "Generating" }
+]

--- a/website/src/docs/adk/generating.md
+++ b/website/src/docs/adk/generating.md
@@ -102,34 +102,7 @@ Tools are orchestrated by ADK natively, which means:
 
 ### Setup
 
-Pass tools to the AI SDK and call `adk()` as usual:
-
-```typescript
-import { adk } from '@react-native-ai/adk'
-import { generateText, tool } from 'ai'
-import { z } from 'zod'
-
-const getCurrentTime = tool({
-  description: 'Get the current time for a city',
-  inputSchema: z.object({
-    city: z.string(),
-  }),
-  execute: async ({ city }) => ({
-    city,
-    time: new Date().toLocaleTimeString(),
-  }),
-})
-
-await adk.prepareNano()
-
-const { text } = await generateText({
-  model: adk(),
-  tools: { getCurrentTime },
-  prompt: 'What time is it in Warsaw?',
-})
-```
-
-ADK also needs tool executors registered on the provider. Use `createAdkProvider` with `availableTools`:
+ADK needs tool executors registered both in the AI SDK and on the provider. Use `createAdkProvider` with `availableTools`, then pass tools to the AI SDK and call `adk()` as usual. Example:
 
 ```typescript
 import { createAdkProvider } from '@react-native-ai/adk'

--- a/website/src/docs/adk/generating.md
+++ b/website/src/docs/adk/generating.md
@@ -1,0 +1,304 @@
+# Generating
+
+You can generate responses using ADK with the Vercel AI SDK's `generateText` or `streamText` functions. ADK orchestrates the agent loop natively on Android while the provider bridges tool execution and streaming back to JavaScript. Import the default provider, call `adk()` to construct a language model, and pass it to the AI SDK — the default export targets on-device Gemini Nano.
+
+## Requirements
+
+- **Physical Android device with AICore** - Required for Gemini Nano; the device must be capable of running Gemini Nano. Please consult the [ML Kit GenAI documentation](https://developers.google.com/ml-kit/genai#feature-device). We provide runtime checks for this capability - please refer to [Getting Started - On-device Gemini Nano](./getting-started.mdx#on-device-gemini-nano).
+- **Polyfills** - Streaming requires `ReadableStream`; see [Polyfills](../polyfills.md)
+- **Prepare Nano** - Call `prepareNano()` or `model.prepare()` before first on-device use (see [Getting Started - On-device Gemini Nano](./getting-started.mdx#on-device-gemini-nano))
+
+## Text Generation
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'Explain quantum computing in simple terms',
+})
+```
+
+### Cloud Gemini
+
+Cloud models use ADK's `LlmAgent` with Google's Gemini API. This is useful when Gemini Nano is unavailable, you need a more capable model, or you want to develop on an emulator without AICore. Create a provider with `modelType: 'gemini'` and an API key:
+
+```typescript
+import { createAdkProvider } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+const adk = createAdkProvider({
+  modelType: 'gemini',
+  modelName: 'gemini-2.5-flash',
+  apiKey: process.env.GOOGLE_API_KEY,
+})
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'Explain quantum computing in simple terms',
+})
+```
+
+Cloud models do not require a separate download or prepare step.
+
+> Do not embed API keys in production client apps. Prefer a backend proxy or secure runtime configuration.
+
+## Streaming
+
+Stream responses for real-time output:
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { streamText } from 'ai'
+
+await adk.prepareNano()
+
+const { textStream } = await streamText({
+  model: adk(),
+  prompt: 'Write a short story about a robot learning to paint',
+})
+
+for await (const delta of textStream) {
+  console.log(delta)
+}
+```
+
+During streaming, the provider emits standard AI SDK stream parts: `text-start`, `text-delta`, `text-end`, and `finish` with usage metadata.
+
+## Usage Metadata
+
+ADK returns token usage in response events (`promptTokenCount`, `candidatesTokenCount`, `totalTokenCount`). The provider maps this into AI SDK `usage` on both `generateText` results and streaming `finish` events:
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+await adk.prepareNano()
+
+const { usage } = await generateText({
+  model: adk(),
+  prompt: 'Count to five.',
+})
+
+console.log(usage.inputTokens.total) // promptTokenCount
+console.log(usage.outputTokens.total) // candidatesTokenCount
+console.log(usage.raw?.totalTokenCount)
+```
+
+## Tool Calling
+
+Enable ADK agents to call JavaScript tools during generation. Works on both on-device Nano and cloud Gemini.
+
+### Important ADK-Specific Behavior
+
+Tools are orchestrated by ADK natively, which means:
+
+- **Pre-register executors**: Pass tools to `createAdkProvider` via `availableTools` so ADK can invoke their `execute` handlers
+- **Provider-executed**: Streamed tool calls are marked with `providerExecuted: true`
+- **Native agent loop**: ADK runs the multi-turn tool loop; AI SDK `maxSteps` does not control ADK's internal iteration
+
+### Setup
+
+Pass tools to the AI SDK and call `adk()` as usual:
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText, tool } from 'ai'
+import { z } from 'zod'
+
+const getCurrentTime = tool({
+  description: 'Get the current time for a city',
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  execute: async ({ city }) => ({
+    city,
+    time: new Date().toLocaleTimeString(),
+  }),
+})
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  tools: { getCurrentTime },
+  prompt: 'What time is it in Warsaw?',
+})
+```
+
+ADK also needs tool executors registered on the provider. Use `createAdkProvider` with `availableTools`:
+
+```typescript
+import { createAdkProvider } from '@react-native-ai/adk'
+import { generateText, tool } from 'ai'
+import { z } from 'zod'
+
+const getCurrentTime = tool({
+  description: 'Get the current time for a city',
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  execute: async ({ city }) => ({
+    city,
+    time: new Date().toLocaleTimeString(),
+  }),
+})
+
+const adk = createAdkProvider({
+  availableTools: { getCurrentTime },
+})
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  tools: { getCurrentTime },
+  prompt: 'What time is it in Warsaw?',
+})
+```
+
+During streaming, the provider emits `tool-input-start`, `tool-input-delta`, `tool-input-end`, and `tool-call` stream parts when ADK surfaces function calls from the model.
+
+Pass tools through the AI SDK `tools` option as usual; the provider bridges execution to JavaScript while ADK orchestrates the agent loop natively.
+
+### Updating Tools at Runtime
+
+Register tools when creating the provider so ADK can execute them from JavaScript:
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+
+const model = adk()
+
+// Add or replace tools on an existing model instance
+model.updateTools({
+  getCurrentTime,
+})
+```
+
+To register executors at provider creation time:
+
+```typescript
+import { createAdkProvider } from '@react-native-ai/adk'
+import { tool } from 'ai'
+import { z } from 'zod'
+
+const getCurrentTime = tool({
+  description: 'Get the current time for a city',
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) => ({
+    city,
+    time: new Date().toLocaleTimeString(),
+  }),
+})
+
+const adk = createAdkProvider({
+  availableTools: { getCurrentTime },
+})
+
+const model = adk()
+
+model.updateTools({
+  getCurrentTime,
+})
+```
+
+## Multimodal Input
+
+Pass file parts in user messages using the standard AI SDK prompt format:
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  messages: [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'What is in this image?' },
+        {
+          type: 'file',
+          mediaType: 'image/jpeg',
+          data: base64Image,
+        },
+      ],
+    },
+  ],
+})
+```
+
+Supported file data formats:
+
+- **Base64 strings** - Raw base64 or `data:image/jpeg;base64,...` data URLs
+- **`Uint8Array`** - Binary image data
+
+> **Note**: File URLs (`file://` or HTTP) are not supported yet. Pass base64 or `Uint8Array` data directly.
+
+## Structured Output
+
+Generate JSON responses using AI SDK JSON mode:
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'Return a JSON object with name and age fields.',
+  responseFormat: { type: 'json' },
+})
+```
+
+> **Note**: JSON schema constraints (`responseFormat.schema`) are not supported yet. Use JSON mode without a schema, or parse and validate the response in your app.
+
+Streaming structured JSON is not supported by ADK yet.
+
+## Available Options
+
+Configure model behavior with generation options:
+
+| Option        | Type   | Description                                              |
+| ------------- | ------ | -------------------------------------------------------- |
+| `temperature` | number | Controls randomness                                      |
+| `maxTokens`   | number | Maximum tokens to generate (`maxOutputTokens` in AI SDK) |
+| `topP`        | number | Nucleus sampling threshold                               |
+| `topK`        | number | Top-K sampling parameter                                 |
+
+Example:
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'Write a creative story',
+  temperature: 0.8,
+  maxOutputTokens: 500,
+  topP: 0.9,
+  topK: 40,
+})
+```
+
+## Limitations
+
+The following features are not yet supported:
+
+| Feature                            | Status                                       |
+| ---------------------------------- | -------------------------------------------- |
+| `responseFormat.schema`            | Not supported - use JSON mode without schema |
+| Streaming JSON                     | Not supported                                |
+| `toolChoice: { type: 'required' }` | Ignored with a warning - defaults to auto    |
+| File URLs in multimodal prompts    | Not supported - use base64 or `Uint8Array`   |
+| iOS / web                          | Android only                                 |

--- a/website/src/docs/adk/getting-started.mdx
+++ b/website/src/docs/adk/getting-started.mdx
@@ -238,6 +238,7 @@ import { generateText } from 'ai'
 
 const adk = createAdkProvider({
   apiKey: process.env.GOOGLE_API_KEY,
+  modelType: 'gemini',
   modelName: 'gemini-2.5-flash',
   instruction: 'You are a helpful assistant.',
 })
@@ -272,15 +273,15 @@ const model = adk.languageModel()
 
 #### Provider Options
 
-| Option           | Type                       | Description                                                                     |
-| ---------------- | -------------------------- | ------------------------------------------------------------------------------- |
-| `name`           | `string`                   | ADK agent name (default: `react_native_adk_agent`)                              |
-| `description`    | `string`                   | Agent description shown to ADK                                                  |
-| `instruction`    | `string`                   | System instruction for the agent                                                |
-| `modelType`      | `'genai-nano' \| 'gemini'` | On-device or cloud backend (default: `genai-nano`)                              |
-| `modelName`      | `string`                   | Model identifier (default: `gemini-nano`; use `gemini-2.5-flash` for cloud)     |
-| `apiKey`         | `string`                   | Google AI API key - required for cloud `gemini` only                            |
-| `availableTools` | `Record<string, Tool>`     | Tools whose `execute` handlers ADK can call from JavaScript                     |
+| Option           | Type                       | Description                                                                 |
+| ---------------- | -------------------------- | --------------------------------------------------------------------------- |
+| `name`           | `string`                   | ADK agent name (default: `react_native_adk_agent`)                          |
+| `description`    | `string`                   | Agent description shown to ADK                                              |
+| `instruction`    | `string`                   | System instruction for the agent                                            |
+| `modelType`      | `'genai-nano' \| 'gemini'` | On-device or cloud backend (default: `genai-nano`)                          |
+| `modelName`      | `string`                   | Model identifier (default: `gemini-nano`; use `gemini-2.5-flash` for cloud) |
+| `apiKey`         | `string`                   | Google AI API key - required for cloud `gemini` only                        |
+| `availableTools` | `Record<string, Tool>`     | Tools whose `execute` handlers ADK can call from JavaScript                 |
 
 ## Next Steps
 

--- a/website/src/docs/adk/getting-started.mdx
+++ b/website/src/docs/adk/getting-started.mdx
@@ -1,0 +1,287 @@
+import { PackageManagerTabs } from '@theme'
+
+# Getting Started
+
+The ADK provider brings on-device Gemini Nano to Android React Native apps through [Google's Agent Development Kit (ADK)](https://developer.android.com/ai/adk) and the Vercel AI SDK. Gemini Nano runs locally via ML Kit GenAI - provisioned by the Android system through AICore, with no API key and no model files to bundle. You also get cloud Gemini as an option when you need a larger model or broader device support.
+
+## Installation
+
+Install the ADK provider:
+
+<PackageManagerTabs command="install @react-native-ai/adk" />
+
+While you can use the ADK provider standalone, we recommend using it with the Vercel AI SDK for a much better developer experience. The AI SDK provides unified APIs, streaming support, and advanced features. To use with the AI SDK, you'll need v5+ and [required polyfills](../polyfills.md):
+
+<PackageManagerTabs command="install ai" />
+
+## Requirements
+
+- **Android only** - The provider is not available on iOS or web
+- **Android `minSdkVersion` 26 or greater** - Required by ML Kit GenAI / Gemini Nano
+- **React Native New Architecture** - Required for native module functionality
+- **React Native >= 0.76.0**
+- **Gemini Nano** - A physical Android device with AICore support (Android 14+). See the [ML Kit GenAI documentation](https://developers.google.com/ml-kit/genai#feature-device) for device support details.
+
+:::danger Gemini Nano - physical supported device required
+Gemini Nano requires a physical Android device with AICore support and support for the Gemini Nano models. Please consult the [ML Kit GenAI documentation](https://developers.google.com/ml-kit/genai#feature-device).
+
+Cloud Gemini works on all devices supported by ADK & MLKit when an API key is configured.
+:::
+
+## Integration with your app
+
+Consuming apps must set `minSdkVersion` to at least 26. ADK pulls in Google GenAI libraries that duplicate `META-INF/INDEX.LIST`; exclude it in your app packaging via `expo-build-properties`:
+
+### Expo Setup
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "minSdkVersion": 26,
+            "packagingOptions": {
+              "exclude": ["META-INF/INDEX.LIST", "META-INF/DEPENDENCIES"]
+            }
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+After changing CNG config, run:
+
+```bash
+npx expo prebuild --clean
+```
+
+### Bare React Native
+
+Add the following to `android/app/build.gradle`:
+
+```groovy
+android {
+  packagingOptions {
+    excludes += ["META-INF/INDEX.LIST", "META-INF/DEPENDENCIES"]
+  }
+}
+```
+
+Ensure your app's `minSdkVersion` is at least 26.
+
+## Available Model Types
+
+| Model Type            | `modelType`  | Default Name       | Use Case                                                           |
+| --------------------- | ------------ | ------------------ | ------------------------------------------------------------------ |
+| On-device Gemini Nano | `genai-nano` | `gemini-nano`      | Private, offline-capable inference - system-provisioned via AICore |
+| Cloud Gemini          | `gemini`     | `gemini-2.5-flash` | Cloud inference via Google AI API                                  |
+
+## Basic Usage
+
+Import the default ADK provider and call `adk()` to construct a language model, then pass it to the AI SDK. The default export targets on-device Gemini Nano (`gemini-nano`):
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+const supported = await adk.isNanoSupported()
+if (!supported) throw new Error('Gemini Nano not supported on this device')
+
+const ready = await adk.isAvailable()
+if (!ready) throw new Error('Gemini Nano not ready yet')
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'Summarize on-device AI in one sentence.',
+})
+```
+
+See [Cloud Gemini](#cloud-gemini) when you need cloud inference instead.
+
+### On-device Gemini Nano
+
+Gemini Nano runs locally via ML Kit GenAI and is provisioned by the Android system (AICore). The default `adk()` export already targets Nano — check availability and prepare before generating:
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+const supported = await adk.isNanoSupported()
+if (!supported) throw new Error('Gemini Nano not supported on this device')
+
+const ready = await adk.isAvailable('genai-nano')
+if (!ready) throw new Error('Gemini Nano not ready yet')
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'Summarize on-device AI in one sentence.',
+})
+```
+
+To customize the system instruction or register tool executors, create a provider with `createAdkProvider`:
+
+```typescript
+import { createAdkProvider } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+const adk = createAdkProvider({
+  modelType: 'genai-nano',
+  modelName: 'gemini-nano',
+  instruction: 'You are a helpful assistant.',
+})
+
+await adk.prepareNano()
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'Summarize on-device AI in one sentence.',
+})
+```
+
+#### Availability Check
+
+Nano has two separate checks:
+
+| API                             | Label                 | Question                                   |
+| ------------------------------- | --------------------- | ------------------------------------------ |
+| `adk.isNanoSupported()`         | **Device capability** | Can this device ever run Nano?             |
+| `adk.isAvailable('genai-nano')` | **Runtime readiness** | Can I call `prepareNano()` / generate now? |
+
+If `isNanoSupported()` is `false`, `isAvailable('genai-nano')` is also `false`.
+
+Both checks are cheap native calls (no model download), safe to cache at app startup and re-check after resume.
+
+Both checks use ML Kit `Generation.getClient().checkStatus()`:
+
+| Status         | `isNanoSupported()` | `isAvailable('genai-nano')` | Suggested UX                             |
+| -------------- | ------------------- | --------------------------- | ---------------------------------------- |
+| `0`            | `false`             | `false`                     | Hide or disable - not supported          |
+| `1`            | `true`              | `true`                      | Ready - call `prepareNano()`             |
+| `3`            | `true`              | `true`                      | Ready to download - call `prepareNano()` |
+| Other non-zero | `true`              | `false`                     | Show disabled - not ready yet            |
+
+If needed, consult the [ML Kit GenAI Prompt API](https://developers.google.com/ml-kit/genai) for details.
+
+#### Recommended Flow
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+
+const supported = await adk.isNanoSupported()
+if (!supported) {
+  // Device lacks Gemini Nano / AICore support - hide from model picker
+  return
+}
+
+const ready = await adk.isAvailable('genai-nano')
+if (!ready) {
+  // Device supports Nano but ML Kit is not ready yet (e.g. downloading)
+  // Show disabled - do not mark as "Ready"
+  return
+}
+
+await adk.prepareNano()
+const model = adk()
+```
+
+#### Automatic Preparation
+
+`model.prepare()`, `generateText()`, and `streamText()` auto-call `prepareNano()` for `genai-nano` models, but only gate on `isNanoSupported()`. For UI gating, always use `isAvailable('genai-nano')` and handle prepare/generation errors in your chat flow.
+
+```typescript
+import { adk } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+const model = adk()
+
+// Explicit prepare (initializes Nano via ML Kit)
+await model.prepare()
+
+// Or let generation trigger prepare automatically
+await generateText({ model, prompt: 'Hello!' })
+```
+
+### Cloud Gemini
+
+When you need cloud inference - for example on emulators or devices without AICore - create a provider with `modelType: 'gemini'` and an API key:
+
+```typescript
+import { createAdkProvider } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+const adk = createAdkProvider({
+  apiKey: process.env.GOOGLE_API_KEY,
+  modelType: 'gemini',
+  modelName: 'gemini-2.5-flash',
+})
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'What time is it in New York?',
+})
+```
+
+To customize the system instruction or cloud model name:
+
+```typescript
+import { createAdkProvider } from '@react-native-ai/adk'
+import { generateText } from 'ai'
+
+const adk = createAdkProvider({
+  apiKey: process.env.GOOGLE_API_KEY,
+  modelName: 'gemini-2.5-flash',
+  instruction: 'You are a helpful assistant.',
+})
+
+const { text } = await generateText({
+  model: adk(),
+  prompt: 'What time is it in New York?',
+})
+```
+
+> Do not embed API keys in production client apps. Prefer a backend proxy or secure runtime configuration.
+
+Cloud models do not require a separate download or prepare step.
+
+### Custom provider (advanced)
+
+Use `createAdkProvider` when you need to change the model type, agent name, system instruction, API key, or registered tool executors. It returns the same callable interface as the default `adk` export - call it to construct a language model:
+
+```typescript
+const adk = createAdkProvider({
+  name: 'my_agent',
+  description: 'A helpful assistant',
+  instruction: 'You are a concise, friendly assistant.',
+  modelType: 'genai-nano',
+  modelName: 'gemini-nano',
+})
+
+const model = adk()
+// or
+const model = adk.languageModel()
+```
+
+#### Provider Options
+
+| Option           | Type                       | Description                                                                     |
+| ---------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `name`           | `string`                   | ADK agent name (default: `react_native_adk_agent`)                              |
+| `description`    | `string`                   | Agent description shown to ADK                                                  |
+| `instruction`    | `string`                   | System instruction for the agent                                                |
+| `modelType`      | `'genai-nano' \| 'gemini'` | On-device or cloud backend (default: `genai-nano`)                              |
+| `modelName`      | `string`                   | Model identifier (default: `gemini-nano`; use `gemini-2.5-flash` for cloud)     |
+| `apiKey`         | `string`                   | Google AI API key - required for cloud `gemini` only                            |
+| `availableTools` | `Record<string, Tool>`     | Tools whose `execute` handlers ADK can call from JavaScript                     |
+
+## Next Steps
+
+See **[Generating](./generating.md)** for text generation, streaming, tool calling and multimodal input.

--- a/website/src/docs/apple/getting-started.mdx
+++ b/website/src/docs/apple/getting-started.mdx
@@ -1,3 +1,5 @@
+import { PackageManagerTabs } from '@theme'
+
 # Getting Started
 
 The Apple provider enables you to use Apple's on-device AI capabilities with the Vercel AI SDK in React Native applications. This includes language models, text embeddings, and other Apple-provided AI features that run entirely on-device for privacy and performance.
@@ -6,15 +8,11 @@ The Apple provider enables you to use Apple's on-device AI capabilities with the
 
 Install the Apple provider:
 
-```bash
-npm install @react-native-ai/apple
-```
+<PackageManagerTabs command="install @react-native-ai/apple" />
 
-While you can use the Apple provider standalone, we recommend using it with the Vercel AI SDK for a much better developer experience. The AI SDK provides unified APIs, streaming support, and advanced features. To use with the AI SDK, you'll need v5 and [required polyfills](../polyfills.md):
+While you can use the Apple provider standalone, we recommend using it with the Vercel AI SDK for a much better developer experience. The AI SDK provides unified APIs, streaming support, and advanced features. To use with the AI SDK, you'll need v5+ and [required polyfills](../polyfills.md):
 
-```bash
-npm install ai
-```
+<PackageManagerTabs command="install ai" />
 
 ## Requirements
 
@@ -32,11 +30,11 @@ To use Apple Intelligence with the iOS Simulator, you need to enable it on your 
 Import the Apple provider and use it with the AI SDK:
 
 ```typescript
-import { apple } from '@react-native-ai/apple';
-import { generateText } from 'ai';
+import { apple } from '@react-native-ai/apple'
+import { generateText } from 'ai'
 
 const result = await generateText({
   model: apple(),
-  prompt: 'Explain quantum computing in simple terms'
-});
+  prompt: 'Explain quantum computing in simple terms',
+})
 ```

--- a/website/src/docs/index.md
+++ b/website/src/docs/index.md
@@ -4,7 +4,7 @@ A collection of on-device AI primitives for React Native with first-class Vercel
 
 ## Why On-Device AI?
 
-- **Privacy-first:** All processing happens locally-no data leaves the device
+- **Privacy-first:** All processing happens locally - no data leaves the device
 - **Instant responses:** No network latency, immediate AI capabilities
 - **Offline-ready:** Works anywhere, even without internet
 - **Zero server costs:** No API fees or infrastructure to maintain

--- a/website/src/docs/index.md
+++ b/website/src/docs/index.md
@@ -4,7 +4,7 @@ A collection of on-device AI primitives for React Native with first-class Vercel
 
 ## Why On-Device AI?
 
-- **Privacy-first:** All processing happens locally—no data leaves the device
+- **Privacy-first:** All processing happens locally-no data leaves the device
 - **Instant responses:** No network latency, immediate AI capabilities
 - **Offline-ready:** Works anywhere, even without internet
 - **Zero server costs:** No API fees or infrastructure to maintain
@@ -30,6 +30,17 @@ Native integration with Apple's on-device AI capabilities through `@react-native
 
 Production-ready with instant availability on supported iOS devices.
 
+### Google ADK
+
+Run Gemini Nano on-device on Android using Google's Agent Development Kit through `@react-native-ai/adk`. Gemini Nano is system-provisioned via AICore - no API key, no model files to bundle. Cloud Gemini is also available when you need a larger model.
+
+- **On-device Gemini Nano** - Private, offline-capable inference via ML Kit GenAI, provisioned by the system
+- **Cloud Gemini** — Optional cloud inference via ADK `LlmAgent` and Google AI API
+- **Tool calling** - Native ADK agent loop with JavaScript tool executors
+- **Streaming** - Real-time text and tool-call stream parts
+
+Android-only. See the [ADK docs](./adk/getting-started) for setup and API details.
+
 ### Llama Engine
 
 Run any GGUF model from HuggingFace locally using `llama.rn` through `@react-native-ai/llama`:
@@ -54,14 +65,10 @@ Run any open-source LLM locally using MLC's optimized runtime through `@react-na
 
 Build UIs from tool-calling models with `@react-native-ai/json-ui`:
 
-- **Tool-based spec** — Model calls tools to add/set/delete nodes and props
-- **GenerativeUIView** — Renders the spec in React Native; override styles or supply a custom node renderer
-- **Small-model friendly** — Designed for on-device models with limited context
+- **Tool-based spec** - Model calls tools to add/set/delete nodes and props
+- **GenerativeUIView** - Renders the spec in React Native; override styles or supply a custom node renderer
+- **Small-model friendly** - Designed for on-device models with limited context
 
 See the [JSON UI docs](./json-ui/getting-started) for setup and API.
-
-### Google (Coming Soon)
-
-Support for Google's on-device models is planned for future releases.
 
 Get started by choosing the approach that fits your needs!

--- a/website/src/docs/json-ui/getting-started.mdx
+++ b/website/src/docs/json-ui/getting-started.mdx
@@ -1,3 +1,5 @@
+import { PackageManagerTabs } from '@theme'
+
 # Getting Started
 
 Lightweight JSON UI tooling for React Native with the Vercel AI SDK. The model builds and updates a UI by calling tools (e.g. add node, set props); you render the resulting spec with `GenerativeUIView`.
@@ -21,9 +23,7 @@ There exists a great library for streaming interfaces: [`json-render`](https://g
 
 ## Installation
 
-```bash
-bun add @react-native-ai/json-ui
-```
+<PackageManagerTabs command="install @react-native-ai/json-ui" />
 
 ## Quick Start
 

--- a/website/src/docs/llama/getting-started.mdx
+++ b/website/src/docs/llama/getting-started.mdx
@@ -1,3 +1,5 @@
+import { PackageManagerTabs } from '@theme'
+
 # Getting Started
 
 The Llama provider enables you to run GGUF models directly on-device in React Native applications using [llama.rn](https://github.com/mybigday/llama.rn). This allows you to download and run any GGUF model from HuggingFace for privacy, performance, and offline capabilities.
@@ -6,15 +8,11 @@ The Llama provider enables you to run GGUF models directly on-device in React Na
 
 Install the Llama provider and its peer dependencies:
 
-```bash
-npm install @react-native-ai/llama llama.rn
-```
+<PackageManagerTabs command="install @react-native-ai/llama llama.rn" />
 
-While you can use the Llama provider standalone, we recommend using it with the Vercel AI SDK for a much better developer experience. The AI SDK provides unified APIs, streaming support, and advanced features. To use with the AI SDK, you'll need v5 and [required polyfills](../polyfills.md):
+While you can use the Llama provider standalone, we recommend using it with the Vercel AI SDK for a much better developer experience. The AI SDK provides unified APIs, streaming support, and advanced features. To use with the AI SDK, you'll need v5+ and [required polyfills](../polyfills.md):
 
-```bash
-npm install ai
-```
+<PackageManagerTabs command="install ai" />
 
 ## Requirements
 
@@ -52,11 +50,11 @@ For all other installation tips and tricks, refer to the [llama.rn Expo document
 
 The Llama provider supports multiple model types:
 
-| Model Type | Method | Use Case |
-| --- | --- | --- |
-| Language Model | `llama.languageModel()` | Text generation, chat, reasoning |
+| Model Type      | Method                       | Use Case                            |
+| --------------- | ---------------------------- | ----------------------------------- |
+| Language Model  | `llama.languageModel()`      | Text generation, chat, reasoning    |
 | Embedding Model | `llama.textEmbeddingModel()` | Text embeddings for RAG, similarity |
-| Speech Model | `llama.speechModel()` | Text-to-speech with vocoder |
+| Speech Model    | `llama.speechModel()`        | Text-to-speech with vocoder         |
 
 ## Basic Usage
 
@@ -67,7 +65,9 @@ import { llama, downloadModel } from '@react-native-ai/llama'
 import { streamText } from 'ai'
 
 // Download model from HuggingFace - returns the file path
-const modelPath = await downloadModel('ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf')
+const modelPath = await downloadModel(
+  'ggml-org/SmolLM3-3B-GGUF/SmolLM3-Q4_K_M.gguf'
+)
 
 // Create model instance with the path
 const model = llama.languageModel(modelPath)

--- a/website/src/docs/mlc/getting-started.mdx
+++ b/website/src/docs/mlc/getting-started.mdx
@@ -1,3 +1,5 @@
+import { PackageManagerTabs } from '@theme'
+
 # Getting Started
 
 The MLC provider enables you to run large language models directly on-device in React Native applications. This includes popular models like Llama, Phi-3, Mistral, and Qwen that run entirely on-device for privacy, performance, and offline capabilities.
@@ -6,15 +8,11 @@ The MLC provider enables you to run large language models directly on-device in 
 
 Install the MLC provider:
 
-```bash
-npm install @react-native-ai/mlc
-```
+<PackageManagerTabs command="install @react-native-ai/mlc" />
 
-While you can use the MLC provider standalone, we recommend using it with the Vercel AI SDK for a much better developer experience. The AI SDK provides unified APIs, streaming support, and advanced features. To use with the AI SDK, you'll need v5 and [required polyfills](../polyfills.md):
+While you can use the MLC provider standalone, we recommend using it with the Vercel AI SDK for a much better developer experience. The AI SDK provides unified APIs, streaming support, and advanced features. To use with the AI SDK, you'll need v5+ and [required polyfills](../polyfills.md):
 
-```bash
-npm install ai
-```
+<PackageManagerTabs command="install ai" />
 
 ## Requirements
 
@@ -36,9 +34,7 @@ For Expo projects, add the MLC config plugin to automatically configure the incr
 ```json
 {
   "expo": {
-    "plugins": [
-      "@react-native-ai/mlc"
-    ]
+    "plugins": ["@react-native-ai/mlc"]
   }
 }
 ```
@@ -56,7 +52,7 @@ npx expo prebuild --clean
 If you're not using Expo or prefer manual configuration, add the "Increased Memory Limit" capability in Xcode:
 
 1. Open your iOS project in Xcode
-2. Navigate to your target's **Signing & Capabilities** tab  
+2. Navigate to your target's **Signing & Capabilities** tab
 3. Click **+ Capability** and add "Increased Memory Limit"
 
 ## Basic Usage
@@ -64,18 +60,18 @@ If you're not using Expo or prefer manual configuration, add the "Increased Memo
 Import the MLC provider and use it with the AI SDK:
 
 ```typescript
-import { mlc } from '@react-native-ai/mlc';
-import { generateText } from 'ai';
+import { mlc } from '@react-native-ai/mlc'
+import { generateText } from 'ai'
 
-const model = mlc.languageModel("Llama-3.2-3B-Instruct");
+const model = mlc.languageModel('Llama-3.2-3B-Instruct')
 
-await model.download();
-await model.prepare();
+await model.download()
+await model.prepare()
 
 const result = await generateText({
   model,
-  prompt: 'Explain quantum computing in simple terms'
-});
+  prompt: 'Explain quantum computing in simple terms',
+})
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary

Add user-facing ADK docs to the website and align the default provider with on-device Gemini Nano.

Feats:
- Change default `adk()` to `genai-nano` / `gemini-nano` (was cloud `gemini-2.5-flash`)

Docs:
- Add ADK docs (`getting-started`, `generating`) with Nano-first examples using `import { adk }` + `adk()`, and `createAdkProvider` for advanced/cloud usage
- Register ADK in docs nav and replace the "Google (Coming Soon)" intro section
- Convert getting-started of all providers pages to `.mdx` with `PackageManagerTabs`
