### PR TITLE
chore: integrate lefthook & commitlint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-prettier": "^5.5.1",
         "eslint-plugin-simple-import-sort": "^12.1.1",
+        "lefthook": "^1.12.2",
         "prettier": "^3.7.4",
         "react-native-builder-bob": "^0.40.17",
         "release-it": "^19.1.0",
@@ -1944,6 +1945,28 @@
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
 
     "lan-network": ["lan-network@0.1.7", "", { "bin": { "lan-network": "dist/lan-network-cli.js" } }, "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ=="],
+
+    "lefthook": ["lefthook@1.13.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "1.13.6", "lefthook-darwin-x64": "1.13.6", "lefthook-freebsd-arm64": "1.13.6", "lefthook-freebsd-x64": "1.13.6", "lefthook-linux-arm64": "1.13.6", "lefthook-linux-x64": "1.13.6", "lefthook-openbsd-arm64": "1.13.6", "lefthook-openbsd-x64": "1.13.6", "lefthook-windows-arm64": "1.13.6", "lefthook-windows-x64": "1.13.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@1.13.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@1.13.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@1.13.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@1.13.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@1.13.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@1.13.6", "", { "os": "linux", "cpu": "x64" }, "sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@1.13.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@1.13.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@1.13.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@1.13.6", "", { "os": "win32", "cpu": "x64" }, "sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: true
+  commands:
+    eslint:
+      glob: '*.{js,ts,tsx,mjs}'
+      exclude: 'website/**'
+      run: bunx eslint --fix {staged_files}
+      stage_fixed: true
+    typecheck:
+      run: bun run typecheck
+
+commit-msg:
+  commands:
+    commitlint:
+      run: bunx commitlint --edit {1}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "@react-native-ai/monorepo",
   "private": true,
   "scripts": {
+    "prepare": "lefthook install",
     "typecheck": "bun run --filter='*' typecheck",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "lint:fix": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "release": "release-it",
     "build": "bun run --filter='@react-native-ai/*' prepare",
     "postinstall": "bash packages/mlc/scripts/fetch-prebuilt.sh"
@@ -30,6 +32,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "lefthook": "^1.12.2",
     "prettier": "^3.7.4",
     "react-native-builder-bob": "^0.40.17",
     "release-it": "^19.1.0",

--- a/packages/adk/src/NativeAdkEngine.ts
+++ b/packages/adk/src/NativeAdkEngine.ts
@@ -3,7 +3,7 @@ import { Platform, TurboModuleRegistry } from 'react-native'
 import type {
   EventEmitter,
   UnsafeObject,
-} from 'react-native/Libraries/Types/CodegenTypes'
+} from 'react-native/Libraries/Types/CodegenTypesNamespace'
 
 export type AdkMessageRole = 'assistant' | 'system' | 'user'
 

--- a/packages/apple-llm/src/NativeAppleLLM.ts
+++ b/packages/apple-llm/src/NativeAppleLLM.ts
@@ -3,7 +3,7 @@ import { TurboModuleRegistry } from 'react-native'
 import type {
   EventEmitter,
   UnsafeObject,
-} from 'react-native/Libraries/Types/CodegenTypes'
+} from 'react-native/Libraries/Types/CodegenTypesNamespace'
 
 export interface AppleMessage {
   role: 'assistant' | 'system' | 'tool' | 'user'

--- a/packages/apple-llm/src/NativeAppleSpeech.ts
+++ b/packages/apple-llm/src/NativeAppleSpeech.ts
@@ -1,6 +1,6 @@
 import type { TurboModule } from 'react-native'
 import { TurboModuleRegistry } from 'react-native'
-import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes'
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypesNamespace'
 
 import { addWAVHeader } from './utils'
 

--- a/packages/mlc/src/NativeMLCEngine.ts
+++ b/packages/mlc/src/NativeMLCEngine.ts
@@ -1,6 +1,6 @@
 import type { TurboModule } from 'react-native'
 import { TurboModuleRegistry } from 'react-native'
-import type { EventEmitter } from 'react-native/Libraries/Types/CodegenTypes'
+import type { EventEmitter } from 'react-native/Libraries/Types/CodegenTypesNamespace'
 
 export interface ModelConfig {
   model_id?: string


### PR DESCRIPTION
This PR:
- integrates lefthook and commitlint to lint commit messages, typecheck & lint files
- lefthook will lint in fix mode (i.e., rewrite) files on pre-commit to ensure no non-aligned formatting is committed
- typecheck so far would not pass due to invalid type imports from react-native (was: `CodegenTypes.js` from Flow, is: `CodegenTypesNamespace.d.ts` - proper type declarations), which has been addressed